### PR TITLE
Default LanguageTag.ToString() to formatted

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/Globalization/LanguageTagToStringBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Globalization/LanguageTagToStringBenchmarks.cs
@@ -1,17 +1,16 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Globalization;
 using BenchmarkDotNet.Attributes;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Globalization;
-using DSE.Open.Values;
 
 namespace DSE.Open.Benchmarks.Globalization;
 
+#pragma warning disable CA1822 // Mark members as static
 
 [MemoryDiagnoser]
-public class LanguageTagTryFormatBenchmarks
+public class LanguageTagToStringBenchmarks
 {
     private static readonly LanguageTag[] s_tags = new[]
     {
@@ -28,31 +27,27 @@ public class LanguageTagTryFormatBenchmarks
     };
 
     [Benchmark]
-    public void TryFormatNormalized() => s_tags.ForEach(t =>
+    public void ToStringFormatted() => s_tags.ForEach(t =>
     {
-        Span<char> b = stackalloc char[t.Length];
-        _ = t.TryFormat(b, out var cw, "N".AsSpan(), CultureInfo.InvariantCulture);
-    });
-
-    [Benchmark]
-    public void TryFormatLowercase() => s_tags.ForEach(t =>
-    {
-        Span<char> b = stackalloc char[t.Length];
-        _ = t.TryFormat(b, out var cw, "L".AsSpan(), CultureInfo.InvariantCulture);
-    });
-
-    [Benchmark]
-    public void TryFormatUppercase() => s_tags.ForEach(t =>
-    {
-        Span<char> b = stackalloc char[t.Length];
-        _ = t.TryFormat(b, out var cw, "U".AsSpan(), CultureInfo.InvariantCulture);
+        t.ToString();
     });
 
     [Benchmark(Baseline = true)]
-    public void TryFormatDefault() => s_tags.ForEach(t =>
+    public void ToStringUnformatted() => s_tags.ForEach(t =>
     {
-        Span<char> b = stackalloc char[t.Length];
-        _ = t.TryFormat(b, out var cw, default, CultureInfo.InvariantCulture);
+        t.ToStringUnformatted();
+    });
+
+    [Benchmark]
+    public void ToStringLower() => s_tags.ForEach(t =>
+    {
+        t.ToStringLower();
+    });
+
+    [Benchmark]
+    public void ToStringUpper() => s_tags.ForEach(t =>
+    {
+        t.ToStringUpper();
     });
 }
 

--- a/benchmarks/DSE.Open.Benchmarks/Text/StringHelperRemovePunctuationBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Text/StringHelperRemovePunctuationBenchmarks.cs
@@ -51,3 +51,5 @@ public class StringHelperRemovePunctuationBenchmarks
     [Benchmark]
     public string RemovePunctuation_Small_Punctuation() => StringHelper.RemovePunctuation(SmallPunctuation);
 }
+
+#pragma warning restore CA1822 // Mark members as static

--- a/gen/DSE.Open.Values.Generators/ValueTypesGenerator.cs
+++ b/gen/DSE.Open.Values.Generators/ValueTypesGenerator.cs
@@ -399,6 +399,17 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
                     && ps3.Type is NullableTypeSyntax nts3);
             }
 
+            // ToString
+
+            var toStringMethods = instanceMethods.Where(s => s.Identifier.ValueText == "ToString").ToArray();
+
+            var emitToStringOverrideMethod = true;
+
+            if (toStringMethods.Length > 0)
+            {
+                emitToStringOverrideMethod = !toStringMethods.Any(s => s.ParameterList.Parameters.Count == 0);
+            }
+
 
             var structMembers = namedTypeSymbol.GetMembers();
 
@@ -444,6 +455,7 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
             spec.EmitEqualsMethod = emitEqualsMethod;
             spec.EmitGetHashCodeMethod = emitGetHashCodeMethod;
             spec.EmitTryFormatMethod = emitTryFormatMethod;
+            spec.EmitToStringOverrideMethod = emitToStringOverrideMethod;
 
             spec.UseGetString = useGetStringMethod;
             spec.UseGetStringSpan = useGetStringSpanMethod;

--- a/src/DSE.Open.Globalization/LanguageTag.cs
+++ b/src/DSE.Open.Globalization/LanguageTag.cs
@@ -129,7 +129,13 @@ public readonly partial struct LanguageTag
     /// Returns the language tag as a string, formatted as recommended in RFC5646.
     /// </summary>
     /// <returns>The language tag as a string, formatted as recommended in RFC5646.</returns>
-    public string ToStringNormalized() => ToString("N", CultureInfo.InvariantCulture);
+    public override string ToString() => ToString("N", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Returns the language tag as a string, with formatting .
+    /// </summary>
+    /// <returns></returns>
+    public string ToStringUnformatted() => _value.ToString();
 
     public string ToStringLower() => _value.ToStringLower();
 

--- a/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
+++ b/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
@@ -142,14 +142,6 @@ public readonly partial struct LanguageTag
     public string ToStringInvariant()
         => ToStringInvariant(default);
 
-    /// <summary>
-    /// Gets a representation of the LanguageTag value as a string with default formatting options.
-    /// </summary>
-    /// <returns>
-    /// A representation of the LanguageTag value.
-    /// </returns>
-    public override string ToString() => ToString(default, default);
-
     // ISpanParsable<T>
 
     public static bool TryParse(


### PR DESCRIPTION
This is quite a bit more expensive than unformatted. However, it is likely what is wanted more often than not. Have added `ToStringUnformatted()` for occasions when speed is preferred.

```c#
[MemoryDiagnoser]
public class LanguageTagToStringBenchmarks
{
    private static readonly LanguageTag[] s_tags = new[]
    {
        LanguageTag.EnglishAustralia,
        LanguageTag.EnglishCanada,
        LanguageTag.EnglishUk,
        LanguageTag.EnglishUs,
        LanguageTag.EnglishIndia,
        LanguageTag.EnglishIreland,
        LanguageTag.EnglishNewZealand,
        LanguageTag.EnglishSouthAfrica,
        LanguageTag.Parse("fr-FR"),
        LanguageTag.Parse("en-CA-x-ca"),
    };

    [Benchmark]
    public void ToStringFormatted() => s_tags.ForEach(t =>
    {
        t.ToString();
    });

    [Benchmark(Baseline = true)]
    public void ToStringUnformatted() => s_tags.ForEach(t =>
    {
        t.ToStringUnformatted();
    });

    [Benchmark]
    public void ToStringLower() => s_tags.ForEach(t =>
    {
        t.ToStringLower();
    });

    [Benchmark]
    public void ToStringUpper() => s_tags.ForEach(t =>
    {
        t.ToStringUpper();
    });
}
```

|              Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|-------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
|   ToStringFormatted | 537.7 ns | 3.44 ns | 3.21 ns |  3.57 |    0.03 | 0.0172 |     336 B |        1.00 |
| ToStringUnformatted | 150.5 ns | 1.06 ns | 0.99 ns |  1.00 |    0.00 | 0.0176 |     336 B |        1.00 |
|       ToStringLower | 157.2 ns | 1.21 ns | 1.13 ns |  1.04 |    0.01 | 0.0176 |     336 B |        1.00 |
|       ToStringUpper | 157.4 ns | 1.61 ns | 1.50 ns |  1.05 |    0.01 | 0.0176 |     336 B |        1.00 |

```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22631.1835)
13th Gen Intel Core i9-13900K, 1 CPU, 32 logical and 24 physical cores
.NET SDK=7.0.302
  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
```