### PR TITLE
Update MessageDispatcher to use generic message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/
+

--- a/src/DSE.Open.Mediators/IMessageDispatcher.cs
+++ b/src/DSE.Open.Mediators/IMessageDispatcher.cs
@@ -18,4 +18,15 @@ public interface IMessageDispatcher
     /// <exception cref="ArgumentNullException"><paramref name="message"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">No handlers are registered for the type of the message.</exception>
     Task PublishAsync(IMessage message, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Publishes the message to one or more registered <see cref="IMessageHandler{TMessage}"/>
+    /// implementations where TMessage is the type of <paramref name="message"/>.
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"><paramref name="message"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">No handlers are registered for the type of the message.</exception>
+    Task PublishAsync<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : IMessage;
 }


### PR DESCRIPTION
The important change is f4eacafd37acc5712b0b591cba3a396c500a90af which adds a generic version for message handlers which avoids the need to reflect on objects to invoke `HandleAsync`.

The second change f0dd2b80f4198009fd07a26b112fff7e3383fe66 waits all tasks at once, so we can handle with multiple handlers concurrently if needed. I assume, given they are different handlers, there should be no issues with concurrency.

Another thing to note is that I don't think removing the existing reflection-based overload is a breaking change (because the current one has the same signature, but is more specific, so will take precedence anyway) so if there is no need for it, we can remove this too. 