### PR TITLE
Change value constructors back to private

### DIFF
--- a/gen/DSE.Open.Values.Generators/Model/ValueTypeSpec.cs
+++ b/gen/DSE.Open.Values.Generators/Model/ValueTypeSpec.cs
@@ -48,7 +48,7 @@ internal abstract class ValueTypeSpec
 
     public bool EmitConstructor { get; set; } = true;
     
-    public Accessibility ConstructorAccessibility { get; set; } = Accessibility.Internal;
+    public Accessibility ConstructorAccessibility { get; set; } = Accessibility.Private;
     
     public string ConstructorAccessibilityValue => AccessibilityHelper.GetKeyword(ConstructorAccessibility);
 

--- a/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode.g.cs
+++ b/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct CountryCode
     private readonly AsciiChar2 _value;
     private readonly bool _initialized;
 
-    internal CountryCode(AsciiChar2 value, bool skipValidation = false)
+    private CountryCode(AsciiChar2 value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode3.g.cs
+++ b/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode3.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct CountryCode3
     private readonly AsciiChar3 _value;
     private readonly bool _initialized;
 
-    internal CountryCode3(AsciiChar3 value, bool skipValidation = false)
+    private CountryCode3(AsciiChar3 value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageCode2.g.cs
+++ b/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageCode2.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct LanguageCode2
     private readonly AsciiChar2 _value;
     private readonly bool _initialized;
 
-    internal LanguageCode2(AsciiChar2 value, bool skipValidation = false)
+    private LanguageCode2(AsciiChar2 value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
+++ b/src/DSE.Open.Globalization/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct LanguageTag
     private readonly AsciiString _value;
     private readonly bool _initialized;
 
-    internal LanguageTag(AsciiString value, bool skipValidation = false)
+    private LanguageTag(AsciiString value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/UriAsciiPath.cs
+++ b/src/DSE.Open.Values/UriAsciiPath.cs
@@ -364,5 +364,5 @@ public readonly partial struct UriAsciiPath : IComparableValue<UriAsciiPath, Asc
     /// Creates a new <see cref="UriPath"/> from this <see cref="UriAsciiPath"/>.
     /// </summary>
     /// <returns></returns>
-    public UriPath ToUriPath() => new(_value.ToCharSequence(), skipValidation: true);
+    public UriPath ToUriPath() => UriPath.FromUriAsciiPath(this);
 }

--- a/src/DSE.Open.Values/UriPath.cs
+++ b/src/DSE.Open.Values/UriPath.cs
@@ -341,4 +341,10 @@ public readonly partial struct UriPath : IComparableValue<UriPath, CharSequence>
 
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
+    /// <summary>
+    /// Converts the <paramref name="uriAsciiPath"/> to a <see cref="UriPath"/>.
+    /// </summary>
+    /// <param name="uriAsciiPath"></param>
+    /// <returns></returns>
+    public static UriPath FromUriAsciiPath(UriAsciiPath uriAsciiPath) => new(CharSequence.FromAsciiString((AsciiString)uriAsciiPath), skipValidation: true);
 }

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaCode.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaCode.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct AlphaCode
     private readonly AsciiString _value;
     private readonly bool _initialized;
 
-    internal AlphaCode(AsciiString value, bool skipValidation = false)
+    private AlphaCode(AsciiString value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaNumericCode.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaNumericCode.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct AlphaNumericCode
     private readonly AsciiString _value;
     private readonly bool _initialized;
 
-    internal AlphaNumericCode(AsciiString value, bool skipValidation = false)
+    private AlphaNumericCode(AsciiString value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AsciiPath.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AsciiPath.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct AsciiPath
     private readonly AsciiString _value;
     private readonly bool _initialized;
 
-    internal AsciiPath(AsciiString value, bool skipValidation = false)
+    private AsciiPath(AsciiString value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ContainsPattern.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ContainsPattern.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct ContainsPattern
     private readonly CharSequence _value;
     private readonly bool _initialized;
 
-    internal ContainsPattern(CharSequence value, bool skipValidation = false)
+    private ContainsPattern(CharSequence value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Percent.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Percent.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct Percent
     private readonly Double _value;
     private readonly bool _initialized;
 
-    internal Percent(Double value, bool skipValidation = false)
+    private Percent(Double value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Ratio.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Ratio.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct Ratio
     private readonly Double _value;
     private readonly bool _initialized;
 
-    internal Ratio(Double value, bool skipValidation = false)
+    private Ratio(Double value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriAsciiPath.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriAsciiPath.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct UriAsciiPath
     private readonly AsciiString _value;
     private readonly bool _initialized;
 
-    internal UriAsciiPath(AsciiString value, bool skipValidation = false)
+    private UriAsciiPath(AsciiString value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriPath.g.cs
+++ b/src/DSE.Open.Values/gen/net7.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriPath.g.cs
@@ -19,7 +19,7 @@ public readonly partial struct UriPath
     private readonly CharSequence _value;
     private readonly bool _initialized;
 
-    internal UriPath(CharSequence value, bool skipValidation = false)
+    private UriPath(CharSequence value, bool skipValidation = false)
     {
 
         if (!skipValidation)

--- a/src/DSE.Open/AsciiString.cs
+++ b/src/DSE.Open/AsciiString.cs
@@ -447,5 +447,8 @@ public readonly partial struct AsciiString
 
     public static bool operator >=(AsciiString left, AsciiString right) => left.CompareTo(right) >= 0;
 
-    public CharSequence ToCharSequence() => new(ToCharArray());
+    /// <summary>
+    /// Converts the <see cref="AsciiString"/> to a <see cref="CharSequence"/>.
+    /// </summary>
+    public CharSequence ToCharSequence() => CharSequence.FromAsciiString(this);
 }

--- a/src/DSE.Open/CharSequence.cs
+++ b/src/DSE.Open/CharSequence.cs
@@ -181,4 +181,11 @@ public readonly struct CharSequence
     public static bool operator >(CharSequence left, CharSequence right) => left.CompareTo(right) > 0;
 
     public static bool operator >=(CharSequence left, CharSequence right) => left.CompareTo(right) >= 0;
+
+    /// <summary>
+    /// Converts the <paramref name="asciiString"/> to a <see cref="CharSequence"/>.
+    /// </summary>
+    /// <param name="asciiString"></param>
+    /// <returns>A new <see cref="CharSequence"/> instance.</returns>
+    public static CharSequence FromAsciiString(AsciiString asciiString) => new(asciiString.ToCharArray());
 }


### PR DESCRIPTION
We decided that a safer approach to exposing internal constructors was to implement `From{Type}` methods on the target struct, and use those. That way the constructors can remain private and tracking use of non-validating constructors it not necessary.

This PR implements

- `CharSequence.FromAsciiString` and `AsciiString.ToCharSequence`
- `UriPath.FromUriAsciiPath` and `UriAsciiPath.ToUriPath`