### PR TITLE
Use new CreateRange in ToReadOnlyValueCollection extension

### DIFF
--- a/src/DSE.Open/Collections/Generic/CollectionExtensions.cs
+++ b/src/DSE.Open/Collections/Generic/CollectionExtensions.cs
@@ -530,8 +530,7 @@ public static class CollectionExtensions
     public static ReadOnlyValueCollection<T> ToReadOnlyValueCollection<T>(this IEnumerable<T> collection)
     {
         Guard.IsNotNull(collection);
-
-        return collection is ReadOnlyValueCollection<T> rovc ? rovc : new ReadOnlyValueCollection<T>(collection);
+        return ReadOnlyValueCollection.CreateRange(collection);
     }
 
     public static ValueCollection<T> ToValueCollection<T>(this IEnumerable<T> collection)


### PR DESCRIPTION
Following on from #21, the static class should be the central place for construction logic (as it performs the various optimisations etc). ToReadOnlyValueCollection should call its methods.