### PR TITLE
Implement IUtf8SpanParsable/Formattable for byte backed types

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/DSE.Open.Benchmarks.csproj
+++ b/benchmarks/DSE.Open.Benchmarks/DSE.Open.Benchmarks.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
     </PropertyGroup>
 
     <ItemGroup>

--- a/benchmarks/DSE.Open.Benchmarks/Text/Json/UriAsciiPathJsonBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Text/Json/UriAsciiPathJsonBenchmarks.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using DSE.Open.Values;
+
+namespace DSE.Open.Benchmarks.Text.Json;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser]
+public class UriAsciiPathJsonBenchmarks
+{
+    private const string Path = "a/b/c/d/e/f/g/h";
+    private static readonly UriAsciiPath s_pathValue = UriAsciiPath.Parse(Path);
+
+    [Benchmark]
+    public UriAsciiPath RoundTrip()
+    {
+        var json = JsonSerializer.Serialize(s_pathValue);
+        return JsonSerializer.Deserialize<UriAsciiPath>(json);
+    }
+}

--- a/src/DSE.Open.Abstractions/IUtf8SpanSerializable.cs
+++ b/src/DSE.Open.Abstractions/IUtf8SpanSerializable.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace DSE.Open;
+
+/// <summary>
+/// Indicates that a type can be written to and read from a span of bytes.
+/// </summary>
+/// <typeparam name="TSelf"></typeparam>
+[SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Required for static interface methods")]
+public interface IUtf8SpanSerializable<TSelf> : IUtf8SpanParsable<TSelf>, IUtf8SpanFormattable
+    where TSelf : IUtf8SpanSerializable<TSelf>
+{
+    /// <summary>
+    /// Gets the maximum number of bytes that a value can be serialized to.
+    /// </summary>
+    static abstract int MaxSerializedByteLength { get; }
+}

--- a/src/DSE.Open.Globalization/LanguageTag.cs
+++ b/src/DSE.Open.Globalization/LanguageTag.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using CommunityToolkit.HighPerformance;
 using CommunityToolkit.HighPerformance.Buffers;
 using DSE.Open.Values;
 using DSE.Open.Values.Text.Json.Serialization;
@@ -56,13 +55,13 @@ public readonly partial struct LanguageTag
     }
 
     public static LanguageTag FromByteSpan(ReadOnlySpan<byte> languageTag)
-        => new(new AsciiString(MemoryMarshal.Cast<byte, AsciiChar>(languageTag).ToArray()));
+        => new(AsciiString.Parse(languageTag, null));
 
     public static LanguageTag FromCharSpan(ReadOnlySpan<char> languageTag)
         => new(AsciiString.Parse(languageTag));
 
     public static bool IsValidValue(ReadOnlySpan<AsciiChar> value)
-        => IsValidValue(MemoryMarshal.Cast<AsciiChar, byte>(value));
+        => IsValidValue(ValuesMarshal.AsBytes(value));
 
     public static bool IsValidValue(ReadOnlySpan<byte> value)
     {

--- a/src/DSE.Open.Values/Text/Json/Serialization/JsonUtf8SpanSerializableValueConverter.cs
+++ b/src/DSE.Open.Values/Text/Json/Serialization/JsonUtf8SpanSerializableValueConverter.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DSE.Open.Values.Text.Json.Serialization;
+
+public sealed class JsonUtf8SpanSerializableValueConverter<TValue, T> : JsonConverter<TValue>
+    where T : IEquatable<T>, IUtf8SpanParsable<T>, IUtf8SpanFormattable
+    where TValue : struct, IValue<TValue, T>, IUtf8SpanSerializable<TValue>
+{
+    public override TValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var valueLength = reader.HasValueSequence
+            ? checked((int)reader.ValueSequence.Length)
+            : reader.ValueSpan.Length;
+
+        byte[]? rented = null;
+
+        Span<byte> buffer = valueLength <= JsonConstants.StackallocByteThreshold
+            ? stackalloc byte[valueLength]
+            : (rented = ArrayPool<byte>.Shared.Rent(valueLength));
+
+        try
+        {
+            var bytes = reader.HasValueSequence
+                ? reader.ValueSequence.ToArray()
+                : reader.ValueSpan;
+
+            var success = TValue.TryParse(bytes, default, out var value);
+
+            if (success)
+            {
+                return value;
+            }
+
+            ThrowHelper.ThrowFormatException($"Could not convert {typeof(TValue).Name} value: {Encoding.UTF8.GetString(bytes)}");
+            return default; // unreachable
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+            }
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
+    {
+        Guard.IsNotNull(writer);
+
+        byte[]? rented = null;
+
+        Span<byte> buffer = TValue.MaxSerializedByteLength <= JsonConstants.StackallocByteThreshold
+            ? stackalloc byte[JsonConstants.StackallocByteThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(TValue.MaxSerializedByteLength));
+
+        try
+        {
+            if (value.TryFormat(buffer, out var bytesWritten, default, default))
+            {
+                writer.WriteStringValue(buffer[..bytesWritten]);
+            }
+            else
+            {
+                ThrowHelper.ThrowFormatException($"Could not convert {typeof(TValue).Name} value: {value}");
+            }
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+            }
+        }
+    }
+}

--- a/src/DSE.Open.Web/Routing/UriAsciiPathRouteConstraint.cs
+++ b/src/DSE.Open.Web/Routing/UriAsciiPathRouteConstraint.cs
@@ -37,7 +37,7 @@ public class UriAsciiPathRouteConstraint : IRouteConstraint, IParameterLiteralNo
     }
 
     private static bool CheckConstraintCore(string? valueString)
-        => string.IsNullOrEmpty(valueString) || UriAsciiPath.IsValidValue(valueString, true);
+        => string.IsNullOrEmpty(valueString) || UriAsciiPath.IsValidValue(valueString);
 
     public bool MatchesLiteral(string parameterName, string literal)
         => CheckConstraintCore(literal);

--- a/src/DSE.Open/Text/Json/Serialization/ByteWritingJsonConverter.cs
+++ b/src/DSE.Open/Text/Json/Serialization/ByteWritingJsonConverter.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DSE.Open.Text.Json.Serialization;
+
+/// <summary>
+/// Base implementation for a <see cref="JsonConverter"/> that reads and writes values from <see cref="byte"/> buffers.
+/// </summary>
+/// <typeparam name="TValue"></typeparam>
+public abstract class ByteWritingJsonConverter<TValue> : JsonConverter<TValue>
+    where TValue : IUtf8SpanFormattable, IUtf8SpanParsable<TValue>
+{
+    protected abstract int GetMaxByteCountToWrite(TValue value);
+
+    protected abstract bool TryParse(ReadOnlySpan<byte> data, [MaybeNullWhen(false)] out TValue value);
+
+    protected abstract bool TryFormat(TValue value, Span<byte> data, out int bytesWritten);
+
+    public override TValue Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var valueLength = reader.HasValueSequence
+            ? checked((int)reader.ValueSequence.Length)
+            : reader.ValueSpan.Length;
+
+        byte[]? rented = null;
+
+        Span<byte> buffer = valueLength <= StackallocThresholds.MaxByteLength
+            ? stackalloc byte[valueLength]
+            : (rented = ArrayPool<byte>.Shared.Rent(valueLength));
+
+        try
+        {
+            var bytes = reader.HasValueSequence
+                ? reader.ValueSequence.ToArray()
+                : reader.ValueSpan;
+
+            if (TryParse(bytes, out var value))
+            {
+                return value;
+            }
+
+            ThrowHelper.ThrowFormatException($"Could not convert {typeof(TValue).Name} value: {buffer.ToArray()}");
+            return default;
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+            }
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
+    {
+        Guard.IsNotNull(writer);
+
+        var byteCount = GetMaxByteCountToWrite(value);
+
+        if (byteCount < 1)
+        {
+            writer.WriteStringValue(string.Empty);
+            return;
+        }
+
+        byte[]? rented = null;
+
+        Span<byte> output = byteCount <= StackallocThresholds.MaxByteLength
+            ? stackalloc byte[byteCount]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+
+        try
+        {
+            if (TryFormat(value, output, out var bytesWritten))
+            {
+                writer.WriteStringValue(output[..bytesWritten]);
+            }
+            else
+            {
+                ThrowHelper.ThrowFormatException($"Could not convert {typeof(TValue).Name} value: {value}");
+            }
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+            }
+        }
+    }
+}

--- a/src/DSE.Open/Text/Json/Serialization/JsonStringAsciiStringConverter.cs
+++ b/src/DSE.Open/Text/Json/Serialization/JsonStringAsciiStringConverter.cs
@@ -3,9 +3,9 @@
 
 namespace DSE.Open.Text.Json.Serialization;
 
-public sealed class JsonStringAsciiStringConverter : SpanParsableCharWritingJsonConverter<AsciiString>
+public sealed class JsonStringAsciiStringConverter : SpanParsableByteWritingJsonConverter<AsciiString>
 {
     public static readonly JsonStringAsciiStringConverter Default = new();
 
-    protected override int GetMaxCharCountToWrite(AsciiString value) => value.Length;
+    protected override int GetMaxByteCountToWrite(AsciiString value) => value.Length;
 }

--- a/src/DSE.Open/Text/Json/Serialization/SpanParsableByteWritingJsonConverter.cs
+++ b/src/DSE.Open/Text/Json/Serialization/SpanParsableByteWritingJsonConverter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace DSE.Open.Text.Json.Serialization;
+
+/// <summary>
+/// Base implementation for a <see cref="JsonConverter"/> that reads and writes values
+/// from <see cref="byte"/> buffers using the implementations provided by types
+/// implementing <see cref="IUtf8SpanFormattable"/> and <see cref="IUtf8SpanParsable{TSelf}"/>.
+/// </summary>
+/// <typeparam name="TValue"></typeparam>
+public abstract class SpanParsableByteWritingJsonConverter<TValue> : ByteWritingJsonConverter<TValue>
+    where TValue : IUtf8SpanFormattable, IUtf8SpanParsable<TValue>
+{
+    protected virtual IFormatProvider FormatProvider => CultureInfo.InvariantCulture;
+
+    protected override bool TryFormat(TValue value, Span<byte> data, out int bytesWritten)
+        => value.TryFormat(data, out bytesWritten, default, FormatProvider);
+
+    protected override bool TryParse(ReadOnlySpan<byte> data, [MaybeNullWhen(false)] out TValue value)
+        => TValue.TryParse(data, FormatProvider, out value);
+}

--- a/src/DSE.Open/ValuesMarshal.cs
+++ b/src/DSE.Open/ValuesMarshal.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace DSE.Open;
+
+internal static class ValuesMarshal
+{
+    public static ReadOnlySpan<AsciiChar> AsAsciiChars(ReadOnlySpan<byte> span) => MemoryMarshal.Cast<byte, AsciiChar>(span);
+
+    public static Span<AsciiChar> AsAsciiChars(Span<byte> span) => MemoryMarshal.Cast<byte, AsciiChar>(span);
+
+    public static ReadOnlySpan<byte> AsBytes(ReadOnlySpan<AsciiChar> span) => MemoryMarshal.AsBytes(span);
+
+    public static Span<byte> AsBytes(Span<AsciiChar> span) => MemoryMarshal.AsBytes(span);
+}

--- a/test/DSE.Open.Tests/AsciiCharTests.cs
+++ b/test/DSE.Open.Tests/AsciiCharTests.cs
@@ -42,4 +42,62 @@ public class AsciiCharTests
 
         Assert.True(AsciiString.SequenceEqualsCaseInsensitive(s1, s2));
     }
+
+    [Fact]
+    public void TryParse_WithAsciiByte_ShouldReturnTrue()
+    {
+        // Arrange
+        var input = "a"u8.ToArray();
+
+        // Act
+        var result = AsciiChar.TryParse(input, default, out var value);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal('a', value);
+    }
+
+    [Fact]
+    public void TryParse_WithNonAsciiByte_ShouldReturnFalse()
+    {
+        // Arrange
+        var input = "ä"u8.ToArray();
+
+        // Act
+        var result = AsciiChar.TryParse(input, default, out var value);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
+    public void TryFormat_WithCorrectBuffer_ShouldReturnTrue()
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        Span<char> buffer = stackalloc char[1];
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, default, default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, charsWritten);
+    }
+
+    [Fact]
+    public void TryFormat_WithInvalidBuffer_ShouldReturnFalse()
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        Span<char> buffer = stackalloc char[0];
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, default, default);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(0, charsWritten);
+    }
 }

--- a/test/DSE.Open.Tests/AsciiStringTests.cs
+++ b/test/DSE.Open.Tests/AsciiStringTests.cs
@@ -127,7 +127,7 @@ public class AsciiStringTests
             i++;
         }
     }
-    
+
     [Fact]
     public void ToCharArray_ShouldReturnCorrectArray()
     {
@@ -141,7 +141,7 @@ public class AsciiStringTests
         // Assert
         Assert.Equal(value.ToCharArray(), result);
     }
-    
+
     [Fact]
     public void ToCharSequence_ShouldReturnCorrectSequence()
     {
@@ -182,5 +182,51 @@ public class AsciiStringTests
 
         // Assert
         Assert.Equal(hashCode1, hashCode2);
+    }
+
+    [Fact]
+    public void TryParse_Utf8_WithValidBytes_ShouldReturnTrue()
+    {
+        // Arrange
+        var bytes = "abcdefghijklmnopqrstuvwxyz"u8;
+
+        // Act
+        var result = AsciiString.TryParse(bytes, default, out var value);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void TryFormat_Utf8_WithCorrectBuffer_ShouldReturnTrue()
+    {
+        // Arrange
+        var bytes = "abcdefghijklmnopqrstuvwxyz"u8;
+        var value = AsciiString.Parse(bytes, null);
+        Span<byte> buffer = stackalloc byte[bytes.Length];
+
+        // Act
+        var success = value.TryFormat(buffer, out var bytesWritten, default, default);
+
+        // Assert
+        Assert.True(success);
+        Assert.Equal(bytes.Length, bytesWritten);
+        Assert.True(buffer.SequenceEqual(bytes));
+    }
+
+    [Fact]
+    public void TryFormat_Utf8_WithIncorrectBuffer_ShouldReturnFalse()
+    {
+        // Arrange
+        var bytes = "abcdefghijklmnopqrstuvwxyz"u8;
+        var value = AsciiString.Parse(bytes, null);
+        Span<byte> buffer = stackalloc byte[bytes.Length - 1];
+
+        // Act
+        var success = value.TryFormat(buffer, out var bytesWritten, default, default);
+
+        // Assert
+        Assert.False(success);
+        Assert.Equal(0, bytesWritten);
     }
 }

--- a/test/DSE.Open.Values.Tests/Text/Json/Serialization/JsonStringUriAsciiPathConverterTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/Json/Serialization/JsonStringUriAsciiPathConverterTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace DSE.Open.Values.Tests.Text.Json.Serialization;
+
+public class JsonStringUriAsciiPathConverterTests
+{
+    [Fact]
+    public void Deserialize_RoundTrip()
+    {
+        var path = UriAsciiPath.Parse("path/to/page");
+
+        var json = JsonSerializer.Serialize(path);
+        var deserialized = JsonSerializer.Deserialize<UriAsciiPath>(json);
+
+        Assert.Equal(path, deserialized);
+    }
+}


### PR DESCRIPTION
| Method    | Mean     | Error   | StdDev  | Gen0   | Allocated |
|---------- |---------:|--------:|--------:|-------:|----------:|
| RoundTrip | 374.3 ns | 0.50 ns | 0.41 ns | 0.0033 |     256 B |
| RoundTrip PR | 200.4 ns | 0.81 ns | 0.72 ns | 0.0012 |      96 B |

```cs
[MemoryDiagnoser]
public class UriAsciiPathJsonBenchmarks
{
    private const string Path = "a/b/c/d/e/f/g/h";
    private static readonly UriAsciiPath s_pathValue = UriAsciiPath.Parse(Path);

    [Benchmark]
    public UriAsciiPath RoundTrip()
    {
        var json = JsonSerializer.Serialize(s_pathValue);
        return JsonSerializer.Deserialize<UriAsciiPath>(json);
    }
}
```