### PR TITLE
Various improvements for AsciiString

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/DSE.Open.Benchmarks.csproj
+++ b/benchmarks/DSE.Open.Benchmarks/DSE.Open.Benchmarks.csproj
@@ -17,4 +17,5 @@
       <ProjectReference Include="..\..\src\DSE.Open\DSE.Open.csproj" />
     </ItemGroup>
 
+
 </Project>

--- a/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringToLowerBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringToLowerBenchmarks.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser]
+public class AsciiStringToLowerBenchmarks
+{
+    private static readonly AsciiString s_value = AsciiString.Parse("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+
+    [Benchmark(Baseline = true)]
+    public AsciiString ToLower_Main()
+    {
+        var result = new AsciiChar[s_value.Length];
+
+        for (var i = 0; i < s_value.Length; i++)
+        {
+            result[i] = s_value.Span[i].ToLower();
+        }
+
+        return new AsciiString(result);
+    }
+
+    [Benchmark]
+    public AsciiString ToLower_WithSpan() => s_value.ToLower();
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringToStringLowerBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringToStringLowerBenchmarks.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser]
+public class AsciiStringToStringLowerBenchmarks
+{
+    private static readonly AsciiString s_singleValue = AsciiString.Parse("A");
+
+    private static readonly AsciiString s_eightValue = AsciiString.Parse("ABCDEFGH");
+
+    private static readonly AsciiString s_longValue = AsciiString.Parse("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+    private static readonly AsciiString s_longerValue = AsciiString.Parse("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
+    private static readonly AsciiString s_veryLongValue =
+        AsciiString.Parse(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+    [Benchmark]
+    public string ToStringLower_Single() => s_singleValue.ToStringLower();
+
+    [Benchmark]
+    public string ToStringLower_Eight() => s_eightValue.ToStringLower();
+
+    [Benchmark]
+    public string ToStringLower_Long() => s_longValue.ToStringLower();
+
+    [Benchmark]
+    public string ToStringLower_Longer() => s_longerValue.ToStringLower();
+
+    [Benchmark]
+    public string ToStringLower_VeryLong() => s_veryLongValue.ToStringLower();
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringTryParseBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/AsciiStringTryParseBenchmarks.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser]
+[DisassemblyDiagnoser(printSource: true)]
+public class AsciiStringTryParseBenchmarks
+{
+    private static ReadOnlySpan<char> Short => "abc".AsSpan();
+
+    private static ReadOnlySpan<char> Long => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".AsSpan();
+
+    [Benchmark]
+    public bool TryParse_Short() => AsciiString.TryParse(Short, out _);
+
+    [Benchmark]
+    public bool TryParse_Long() => AsciiString.TryParse(Long, out _);
+}

--- a/test/DSE.Open.Tests/AsciiStringTests.cs
+++ b/test/DSE.Open.Tests/AsciiStringTests.cs
@@ -57,6 +57,46 @@ public class AsciiStringTests
     }
 
     [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(541)]
+    [InlineData(1000)]
+    [InlineData(3456)]
+    public void ToStringLower_ShouldReturnCorrectString(int length)
+    {
+        // Arrange
+        var chars = new char[length];
+        chars.AsSpan().Fill('A');
+
+        // Act
+        var result = AsciiString.Parse(chars).ToStringLower();
+
+        // Assert
+        Assert.Equal(length, result.Length);
+        Assert.True(result.All(c => c == 'a'));
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(541)]
+    [InlineData(1000)]
+    [InlineData(3456)]
+    public void ToStringUpper_ShouldReturnCorrectString(int length)
+    {
+        // Arrange
+        var chars = new char[length];
+        chars.AsSpan().Fill('a');
+
+        // Act
+        var result = AsciiString.Parse(chars).ToStringUpper();
+
+        // Assert
+        Assert.Equal(length, result.Length);
+        Assert.True(result.All(c => c == 'A'));
+    }
+
+
+    [Theory]
     [InlineData("abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ")]
     public void ToStringUpper_returns_upper_string(string value, string expected)
     {

--- a/test/DSE.Open.Tests/AsciiStringTests.cs
+++ b/test/DSE.Open.Tests/AsciiStringTests.cs
@@ -121,6 +121,7 @@ public class AsciiStringTests
         var c = AsciiString.Parse(value);
 
         var i = 0;
+
         foreach (var item in c)
         {
             Assert.Equal(value[i], item);
@@ -228,5 +229,20 @@ public class AsciiStringTests
         // Assert
         Assert.False(success);
         Assert.Equal(0, bytesWritten);
+    }
+
+    [Fact]
+    public void TryParse_WithLongInput_ShouldCorrectlyParse()
+    {
+        // Arrange
+        var chars = new char[1000];
+        chars.AsSpan().Fill('a');
+
+        // Act
+        var result = AsciiString.TryParse(chars, default, out var value);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1000, value.Length);
     }
 }


### PR DESCRIPTION
### Equals

Speed up in `Equals` and `EqualsCaseInsensitive` (insensitive benchmarked):

| Method                         | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|------------------------------- |----------:|----------:|----------:|------:|----------:|------------:|
| EqualsCaseInsensitive_Main     | 83.266 ns | 0.1704 ns | 0.1594 ns |  1.00 |         - |          NA |
| EqualsEqualsCaseInsensitive_PR |  6.558 ns | 0.0124 ns | 0.0104 ns |  0.08 |         - |          NA |

### Parsing

Speed up in `TryParse` (mostly for longer values when vectorization kicks in)

| Method         |     Mean |    Error |   StdDev |   Gen0 | Allocated |
| -------------- | -------: | -------: | -------: | -----: | --------: |
| TryParse_Short | 14.99 ns | 0.057 ns | 0.047 ns | 0.0002 |      32 B |
| TryParse_Long  | 63.19 ns | 0.510 ns | 0.477 ns | 0.0005 |      88 B |
| TryParse_Short_PR | 13.14 ns | 0.304 ns | 0.660 ns | 0.0002 |      32 B |
| TryParse_Long_PR  | 24.77 ns | 0.523 ns | 1.303 ns | 0.0005 |      88 B |

#### Index out of range fix

Also fixes a bug where parsing an `AsciiString` longer than 256 chars could result in an `IndexOutOfRangeException` (depending on how far over, and how much `ArrayPool.Rent` returns.

### Formatting and Conversion

Should also be a speedup in `ToCharArray` and `ToByteArray` (again, especially for longer values). The same with `TryFormat`, which `ToString` now uses.

The final commit optimises `AsciiString.ToString{Lower|Upper}`. Good perf, and now uses format support for upper and lower in `TryFormat`

| Method                      | Mean       | Error     | StdDev    | Gen0   | Allocated |
|---------------------------- |-----------:|----------:|----------:|-------:|----------:|
| ToStringLower_Single_Main   |   8.125 ns | 0.0880 ns | 0.0823 ns | 0.0001 |      24 B |
| ToStringLower_Eight_Main    |  20.148 ns | 0.1469 ns | 0.1374 ns | 0.0002 |      40 B |
| ToStringLower_Long_Main     |  49.407 ns | 0.2224 ns | 0.2080 ns | 0.0005 |      80 B |
| ToStringLower_Longer_Main   |  98.151 ns | 1.9335 ns | 1.7140 ns | 0.0007 |     128 B |
| ToStringLower_VeryLong_Main | 329.272 ns | 5.0006 ns | 4.6776 ns | 0.0024 |     392 B |
| ToStringLower_Single_PR     |   8.242 ns | 0.0528 ns | 0.0494 ns | 0.0001 |      24 B |
| ToStringLower_Eight_PR      |  15.769 ns | 0.0819 ns | 0.0726 ns | 0.0002 |      40 B |
| ToStringLower_Long_PR       |  20.509 ns | 0.2292 ns | 0.2144 ns | 0.0005 |      80 B |
| ToStringLower_Longer_PR     |  26.514 ns | 0.0539 ns | 0.0478 ns | 0.0008 |     128 B |
| ToStringLower_VeryLong_PR   |  55.102 ns | 0.2653 ns | 0.2215 ns | 0.0024 |     392 B |
