### PR TITLE
Rework BinaryValue

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedBytesBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedBytesBenchmarks.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[ExecutionValidator(true)]
+public class BinaryValueFromEncodedBytesBenchmarks
+{
+    private readonly byte[] _upperHexEncoded;
+    private readonly byte[] _lowerHexEncoded;
+    private readonly byte[] _base64Encoded;
+    private readonly byte[] _base62Encoded;
+
+    public BinaryValueFromEncodedBytesBenchmarks()
+    {
+        var value = BinaryValue.FromEncodedString("Hello, World!");
+
+        Span<byte> buffer = stackalloc byte[128];
+
+        value.TryFormat(buffer, out var base64Written, "B", provider: default);
+        _base64Encoded = buffer[..base64Written].ToArray();
+
+        value.TryFormat(buffer, out var base62Written, "b", provider: default);
+        _base62Encoded = buffer[..base62Written].ToArray();
+
+        value.TryFormat(buffer, out var hexUpperWritten, "X", provider: default);
+        _upperHexEncoded = buffer[..hexUpperWritten].ToArray();
+
+        value.TryFormat(buffer, out var hexLowerWritten, "x", provider: default);
+        _lowerHexEncoded = buffer[..hexLowerWritten].ToArray();
+    }
+
+    [Benchmark]
+    public bool FromBase62EncodedBytes() => BinaryValue.TryFromEncodedBytes(_base62Encoded, BinaryStringEncoding.Base62, out _);
+
+    [Benchmark]
+    public bool FromBase64EncodedBytes() => BinaryValue.TryFromEncodedBytes(_base64Encoded, BinaryStringEncoding.Base64, out _);
+
+    [Benchmark]
+    public bool FromHexUpperBytes() => BinaryValue.TryFromEncodedBytes(_upperHexEncoded, BinaryStringEncoding.HexUpper, out _);
+
+    [Benchmark]
+    public bool FromHexLowerBytes() => BinaryValue.TryFromEncodedBytes(_lowerHexEncoded, BinaryStringEncoding.HexLower, out _);
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedCharsBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedCharsBenchmarks.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[ExecutionValidator(true)]
+public class BinaryValueFromEncodedCharsBenchmarks
+{
+    private readonly char[] _upperHexEncoded;
+    private readonly char[] _lowerHexEncoded;
+    private readonly char[] _base64Encoded;
+    private readonly char[] _base62Encoded;
+
+    public BinaryValueFromEncodedCharsBenchmarks()
+    {
+        var value = BinaryValue.FromEncodedString("Hello, World!");
+
+        Span<char> buffer = stackalloc char[128];
+
+        value.TryFormat(buffer, out var base64Written, "B", provider: default);
+        _base64Encoded = buffer[..base64Written].ToArray();
+
+        Console.WriteLine($"Base64: {new string(_base64Encoded)}");
+
+        value.TryFormat(buffer, out var base62Written, "b", provider: default);
+        _base62Encoded = buffer[..base62Written].ToArray();
+
+        Console.WriteLine($"Base62: {new string(_base62Encoded)}");
+
+        value.TryFormat(buffer, out var hexUpperWritten, "X", provider: default);
+        _upperHexEncoded = buffer[..hexUpperWritten].ToArray();
+
+        Console.WriteLine($"HexUpper: {new string(_upperHexEncoded)}");
+
+        value.TryFormat(buffer, out var hexLowerWritten, "x", provider: default);
+        _lowerHexEncoded = buffer[..hexLowerWritten].ToArray();
+
+        Console.WriteLine($"HexLower: {new string(_lowerHexEncoded)}");
+    }
+
+    [Benchmark]
+    public bool FromBase62EncodedChars() => BinaryValue.TryFromEncodedChars(_base62Encoded, BinaryStringEncoding.Base62, out _);
+
+    [Benchmark]
+    public bool FromBase64EncodedChars() => BinaryValue.TryFromEncodedChars(_base64Encoded, BinaryStringEncoding.Base64, out _);
+
+    [Benchmark]
+    public bool FromHexUpperChars() => BinaryValue.TryFromEncodedChars(_upperHexEncoded, BinaryStringEncoding.HexUpper, out _);
+
+    [Benchmark]
+    public bool FromHexLowerChars() => BinaryValue.TryFromEncodedChars(_lowerHexEncoded, BinaryStringEncoding.HexLower, out _);
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedStringBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueFromEncodedStringBenchmarks.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class BinaryValueFromEncodedStringBenchmarks
+{
+    private static readonly string s_base62Encoded = BinaryValue.FromEncodedString("Hello, World!").ToString(BinaryStringEncoding.Base62);
+
+    private static readonly string s_base64Encoded = BinaryValue.FromEncodedString("Hello, World!").ToString(BinaryStringEncoding.Base64);
+
+    private static readonly string s_hexLowerEncoded = BinaryValue.FromEncodedString("Hello, World!").ToString(BinaryStringEncoding.HexLower);
+
+    private static readonly string s_hexUpperEncoded = BinaryValue.FromEncodedString("Hello, World!").ToString(BinaryStringEncoding.HexUpper);
+
+    [Benchmark]
+    public BinaryValue FromBase62EncodedString() => BinaryValue.FromEncodedString(s_base62Encoded, BinaryStringEncoding.Base62);
+
+    [Benchmark]
+    public BinaryValue FromBase64EncodedString() => BinaryValue.FromEncodedString(s_base64Encoded, BinaryStringEncoding.Base64);
+
+    [Benchmark]
+    public BinaryValue FromHexLowerString() => BinaryValue.FromEncodedString(s_hexLowerEncoded, BinaryStringEncoding.HexLower);
+
+    [Benchmark]
+    public BinaryValue FromHexUpperString() => BinaryValue.FromEncodedString(s_hexUpperEncoded, BinaryStringEncoding.HexUpper);
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueJsonBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueJsonBenchmarks.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace DSE.Open.Benchmarks.Values;
+
+[MemoryDiagnoser(false)]
+public class BinaryValueJsonBenchmarks
+{
+    private static readonly BinaryValue s_value = BinaryValue.FromEncodedString("Hello, world!");
+
+    private static readonly string s_json = JsonSerializer.Serialize(s_value);
+
+    [Benchmark]
+    public BinaryValue Deserialize() => JsonSerializer.Deserialize<BinaryValue>(s_json);
+
+    [Benchmark]
+    public string Serialize() => JsonSerializer.Serialize(s_value);
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToBase62Benchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToBase62Benchmarks.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+public class BinaryValueToBase62Benchmarks
+{
+    private static readonly BinaryValue s_value = BinaryValue.FromEncodedString("Hello, World!");
+    private const string Format = "b";
+
+    [Benchmark]
+    public string ToBase62String() => s_value.ToBase64EncodedString();
+
+    [Benchmark]
+    public bool TryFormatBase62_Chars()
+    {
+        Span<char> buffer = stackalloc char[16];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+
+    [Benchmark]
+    public bool TryFormatBase62_Bytes()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToBase64Benchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToBase64Benchmarks.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class BinaryValueToBase64Benchmarks
+{
+    private static readonly BinaryValue s_value = BinaryValue.FromEncodedString("Hello, World!");
+
+    [Benchmark]
+    public string ToBase64String() => s_value.ToBase64EncodedString();
+
+    [Benchmark]
+    public bool TryFormatBase64_Chars()
+    {
+        Span<char> buffer = stackalloc char[16];
+        return s_value.TryFormat(buffer, out _, format: default, provider: default);
+    }
+
+    [Benchmark]
+    public bool TryFormatBase64_Bytes()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        return s_value.TryFormat(buffer, out _, format: default, provider: default);
+    }
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToHexLowerBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToHexLowerBenchmarks.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class BinaryValueToHexLowerBenchmarks
+{
+    private static readonly BinaryValue s_value = BinaryValue.FromEncodedString("Hello, World!");
+    private const string Format = "x";
+
+    [Benchmark]
+    public string ToHexLowerString() => s_value.ToString(BinaryStringEncoding.HexLower);
+
+    [Benchmark]
+    public bool TryFormatHexLower_Chars()
+    {
+        Span<char> buffer = stackalloc char[26];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+
+    [Benchmark]
+    public bool TryFormatHexLower_Bytes()
+    {
+        Span<byte> buffer = stackalloc byte[26];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+}

--- a/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToHexUpperBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/BinaryValueToHexUpperBenchmarks.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class BinaryValueToHexUpperBenchmarks
+{
+    private static readonly BinaryValue s_value = BinaryValue.FromEncodedString("Hello, World!");
+    private const string Format = "X";
+
+    [Benchmark]
+    public string ToHexUpperString() => s_value.ToString(BinaryStringEncoding.HexUpper);
+
+    [Benchmark]
+    public bool TryFormatHexUpper_Chars()
+    {
+        Span<char> buffer = stackalloc char[26];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+
+    [Benchmark]
+    public bool TryFormatHexUpper_Bytes()
+    {
+        Span<byte> buffer = stackalloc byte[26];
+        return s_value.TryFormat(buffer, out _, Format, provider: default);
+    }
+}

--- a/src/DSE.Open/BinaryValue.Decoding.cs
+++ b/src/DSE.Open/BinaryValue.Decoding.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text;
+
+namespace DSE.Open;
+
+public readonly partial record struct BinaryValue
+{
+    public static BinaryValue FromBase62EncodedString(string value)
+        => FromEncodedString(value, BinaryStringEncoding.Base62);
+
+    public static BinaryValue FromBase64EncodedString(string value)
+        => FromEncodedString(value, BinaryStringEncoding.Base64);
+
+    public static BinaryValue FromEncodedString(string value, BinaryStringEncoding encoding)
+    {
+        switch (encoding)
+        {
+            case BinaryStringEncoding.Base64:
+                return new BinaryValue(Convert.FromBase64String(value), true);
+            case BinaryStringEncoding.HexLower:
+            case BinaryStringEncoding.HexUpper:
+                return new BinaryValue(Convert.FromHexString(value), true);
+            case BinaryStringEncoding.Base62:
+                return new BinaryValue(Base62Converter.FromBase62(value), true);
+            default:
+                return ThrowHelper.ThrowFormatException<BinaryValue>("Invalid encoding provided.");
+        }
+    }
+
+    /// <summary>
+    /// Decodes a string into a <see cref="BinaryValue"/> using the provided <paramref name="encoding"/>.
+    /// </summary>
+    /// <param name="value">The string to decode.</param>
+    /// <param name="encoding">The encoding to use. Defaults to <see cref="Encoding.UTF8"/> if not provided.</param>
+    /// <returns></returns>
+    public static BinaryValue FromEncodedString(string value, Encoding? encoding = null)
+    {
+        encoding ??= Encoding.UTF8;
+        return new BinaryValue(encoding.GetBytes(value), true);
+    }
+
+    public static bool TryFromBase62EncodedString(string value, out BinaryValue binaryValue)
+    {
+        Guard.IsNotNull(value);
+        return TryFromEncodedString(value, BinaryStringEncoding.Base62, out binaryValue);
+    }
+
+    public static bool TryFromBase64EncodedString(string value, out BinaryValue binaryValue)
+    {
+        Guard.IsNotNull(value);
+        return TryFromEncodedString(value, BinaryStringEncoding.Base64, out binaryValue);
+    }
+
+    public static bool TryFromEncodedString(string value, BinaryStringEncoding encoding, out BinaryValue binaryValue)
+    {
+        Guard.IsNotNull(value);
+        return TryFromEncodedChars(value.AsSpan(), encoding, out binaryValue);
+    }
+
+    public static bool TryFromEncodedChars(ReadOnlySpan<char> value, BinaryStringEncoding encoding, out BinaryValue binaryValue) => encoding switch
+    {
+        BinaryStringEncoding.Base62 => TryDecodeFromBase62(value, out binaryValue),
+        BinaryStringEncoding.HexLower => TryDecodeFromLowerHex(value, out binaryValue),
+        BinaryStringEncoding.HexUpper => TryDecodeFromUpperHex(value, out binaryValue),
+        _ => TryDecodeFromBase64(value, out binaryValue)
+    };
+
+    public static bool TryFromEncodedBytes(ReadOnlySpan<byte> value, BinaryStringEncoding encoding, out BinaryValue binaryValue) => encoding switch
+    {
+        BinaryStringEncoding.Base62 => TryDecodeFromBase62(Encoding.UTF8.GetString(value), out binaryValue),
+        BinaryStringEncoding.HexLower => TryDecodeFromHex(value, out binaryValue),
+        BinaryStringEncoding.HexUpper => TryDecodeFromHex(value, out binaryValue),
+        _ => TryDecodeFromBase64(value, out binaryValue)
+    };
+
+    private static bool TryDecodeFromBase64(ReadOnlySpan<char> base64, out BinaryValue binaryValue)
+    {
+        var size = GetRequiredBufferSize(base64.Length, BinaryStringEncoding.Base64);
+
+        byte[]? rented = null;
+
+        Span<byte> buffer = size <= StackallocThresholds.MaxByteLength
+            ? stackalloc byte[size]
+            : (rented = ArrayPool<byte>.Shared.Rent(size));
+
+        try
+        {
+            if (Convert.TryFromBase64Chars(base64, buffer, out var bytesWritten))
+            {
+                binaryValue = new BinaryValue(buffer[..bytesWritten].ToArray(), noCopy: true);
+                return true;
+            }
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        binaryValue = default;
+        return false;
+    }
+
+    private static bool TryDecodeFromBase64(ReadOnlySpan<byte> base64, out BinaryValue binaryValue)
+    {
+        var size = GetRequiredBufferSize(base64.Length, BinaryStringEncoding.Base64);
+
+        byte[]? rented = null;
+
+        Span<byte> bytes = size <= StackallocThresholds.MaxByteLength
+            ? stackalloc byte[size]
+            : (rented = ArrayPool<byte>.Shared.Rent(size));
+
+        try
+        {
+            var status = Base64.DecodeFromUtf8(base64, bytes, out _, out var bytesWritten, isFinalBlock: true);
+
+            if (status == OperationStatus.Done)
+            {
+                binaryValue = new BinaryValue(bytes[..bytesWritten].ToArray(), noCopy: true);
+                return true;
+            }
+
+            Debug.Assert(status == OperationStatus.InvalidData, "We should be sizing the buffer so that this is the only possible status.");
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        binaryValue = default;
+        return false;
+    }
+
+    private static bool TryDecodeFromUpperHex(ReadOnlySpan<char> hex, out BinaryValue binaryValue)
+    {
+        if (HexConverter.IsValidUpperHex(hex))
+        {
+            binaryValue = new BinaryValue(Convert.FromHexString(hex), noCopy: true);
+            return true;
+        }
+
+        binaryValue = default;
+        return false;
+    }
+
+    private static bool TryDecodeFromLowerHex(ReadOnlySpan<char> hex, out BinaryValue binaryValue)
+    {
+        if (HexConverter.IsValidLowerHex(hex))
+        {
+            binaryValue = new BinaryValue(Convert.FromHexString(hex), noCopy: true);
+            return true;
+        }
+
+        binaryValue = default;
+        return false;
+    }
+
+    private static bool TryDecodeFromHex(ReadOnlySpan<byte> hex, out BinaryValue binaryValue)
+    {
+        byte[]? rented = null;
+
+        Span<byte> buffer = hex.Length <= StackallocThresholds.MaxByteLength
+            ? stackalloc byte[hex.Length]
+            : (rented = ArrayPool<byte>.Shared.Rent(hex.Length));
+
+        try
+        {
+            if (HexConverter.TryConvertFromUtf8(hex, buffer, out var bytesWritten))
+            {
+                binaryValue = new BinaryValue(buffer[..bytesWritten].ToArray(), noCopy: true);
+                return true;
+            }
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        binaryValue = default;
+        return false;
+    }
+
+
+    private static bool TryDecodeFromBase62(ReadOnlySpan<char> base62, out BinaryValue binaryValue)
+    {
+        if (Base62Converter.TryFromBase62Chars(base62, out var bytes))
+        {
+            binaryValue = new BinaryValue(bytes, noCopy: true);
+            return true;
+        }
+
+        binaryValue = default;
+        return false;
+    }
+}

--- a/src/DSE.Open/BinaryValue.Encoding.cs
+++ b/src/DSE.Open/BinaryValue.Encoding.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text;
+
+namespace DSE.Open;
+
+public readonly partial record struct BinaryValue
+{
+    /// <summary>
+    /// Formats the value into the provided buffer as Base64.
+    /// </summary>
+    /// <param name="destination">The buffer to write the value into.</param>
+    /// <param name="charsWritten">The number of characters written to the buffer.</param>
+    /// <returns><c>true</c> if the value was successfully written to the buffer; otherwise, <c>false</c>.</returns>
+    public bool TryFormat(Span<char> destination, out int charsWritten)
+        => TryFormat(destination, out charsWritten, null, null);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// The format string is a single character that indicates how to format the value.
+    /// <list>
+    ///     <item><c>null</c> or <c>Empty</c> - Base64</item>
+    ///     <item><c>'B'</c> - Base64</item>
+    ///     <item><c>'b'</c> - Base62</item>
+    ///     <item><c>'x'</c> - Hexadecimal (lowercase)</item>
+    ///     <item><c>'X'</c> - Hexadecimal (uppercase)</item>
+    ///     <item>Any other character will throw a <see cref="FormatException"/>.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public bool TryFormat(
+        Span<char> destination,
+        out int charsWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        if (_value.Length == 0)
+        {
+            charsWritten = 0;
+            return true;
+        }
+
+        if (format.Length > 1)
+        {
+            ThrowHelper.ThrowFormatException($"Invalid format string: '{format}'.");
+            charsWritten = 0; // unreachable
+            return false;
+        }
+
+        if (format.Length == 0 || format[0] == 'B')
+        {
+            return Convert.TryToBase64Chars(_value.Span, destination, out charsWritten);
+        }
+
+        switch (format[0])
+        {
+            case 'b':
+                return Base62Converter.TryEncodeToBase62(_value.Span, destination, out charsWritten);
+            case 'x':
+                return HexConverter.TryEncodeToHexLower(_value.Span, destination, out charsWritten);
+            case 'X':
+                return HexConverter.TryEncodeToHexUpper(_value.Span, destination, out charsWritten);
+            default:
+                charsWritten = 0;
+                return ThrowHelper.ThrowFormatException<bool>($"Invalid format string: '{format}'.");
+        }
+    }
+
+    internal static int GetRequiredBufferSize(int inputLength, BinaryStringEncoding encoding) => encoding switch
+    {
+        BinaryStringEncoding.Base64 or BinaryStringEncoding.Base62 => (int)((uint)inputLength + 2) / 3 * 4,
+        BinaryStringEncoding.HexLower or BinaryStringEncoding.HexUpper => (int)(uint)inputLength * 2,
+        _ => throw new ArgumentOutOfRangeException(nameof(encoding), encoding, null)
+    };
+
+    /// <summary>
+    /// Returns a Base64 string representation of the value.
+    /// </summary>
+    public override string ToString() => ToString(BinaryStringEncoding.Base64);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// The format string is a single character that indicates how to format the value.
+    /// <list>
+    ///     <item><c>null</c> or <c>Empty</c> - Base64</item>
+    ///     <item><c>'B'</c> - Base64</item>
+    ///     <item><c>'b'</c> - Base62</item>
+    ///     <item><c>'x'</c> - Hexadecimal (lowercase)</item>
+    ///     <item><c>'X'</c> - Hexadecimal (uppercase)</item>
+    ///     <item>Any other character will throw a <see cref="FormatException"/>.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public bool TryFormat(
+        Span<byte> utf8Destination,
+        out int bytesWritten,
+        ReadOnlySpan<char> format,
+        IFormatProvider? provider)
+    {
+        if (_value.Length == 0)
+        {
+            bytesWritten = 0;
+            return true;
+        }
+
+        if (format.Length > 1)
+        {
+            ThrowHelper.ThrowFormatException($"Invalid format string: '{format}'.");
+            bytesWritten = 0; // unreachable
+            return false;
+        }
+
+        if (format.Length == 0 || format[0] == 'B')
+        {
+            return Base64.EncodeToUtf8(_value.Span, utf8Destination, out _, out bytesWritten) == OperationStatus.Done;
+        }
+
+        switch (format[0])
+        {
+            case 'b':
+                return Ascii.FromUtf16(Base62Converter.ToBase62String(_value.Span).AsSpan(), utf8Destination, out bytesWritten) == OperationStatus.Done;
+            case 'x':
+                return HexConverter.TryEncodeToHexLower(_value.Span, utf8Destination, out bytesWritten);
+            case 'X':
+                return HexConverter.TryEncodeToHexUpper(_value.Span, utf8Destination, out bytesWritten);
+            default:
+                bytesWritten = 0;
+                return ThrowHelper.ThrowFormatException<bool>($"Invalid format string: '{format}'.");
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// The format string is a single character that indicates how to format the value.
+    /// <list>
+    ///     <item><c>null</c> or <c>Empty</c> - Base64</item>
+    ///     <item><c>'B'</c> - Base64</item>
+    ///     <item><c>'b'</c> - Base62</item>
+    ///     <item><c>'x'</c> - Hexadecimal (lowercase)</item>
+    ///     <item><c>'X'</c> - Hexadecimal (uppercase)</item>
+    ///     <item>Any other character will throw a <see cref="FormatException"/>.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        format ??= "B";
+
+        if (format.Length > 1)
+        {
+            ThrowHelper.ThrowFormatException($"Invalid format string: '{format}'.");
+        }
+
+        if (_value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return format[0] switch
+        {
+            'B' => ToString(BinaryStringEncoding.Base64),
+            'b' => ToString(BinaryStringEncoding.Base62),
+            'x' => ToString(BinaryStringEncoding.HexLower),
+            'X' => ToString(BinaryStringEncoding.HexUpper),
+            _ => ThrowHelper.ThrowFormatException<string>($"Invalid format string: '{format}'."),
+        };
+    }
+
+    public string ToString(BinaryStringEncoding format)
+    {
+        if (_value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return format switch
+        {
+            BinaryStringEncoding.Base62 => Base62Converter.ToBase62String(_value.Span),
+            BinaryStringEncoding.HexUpper => string.Create(_value.Length * 2, this, (span, value) =>
+            {
+                value.TryFormat(span, out var charsWritten, format: "X", provider: null);
+                Debug.Assert(charsWritten == span.Length);
+            }),
+            BinaryStringEncoding.HexLower => string.Create(_value.Length * 2, this, (span, value) =>
+            {
+                value.TryFormat(span, out var charsWritten, format: "x", provider: null);
+                Debug.Assert(charsWritten == span.Length);
+            }),
+            _ => Convert.ToBase64String(_value.Span)
+        };
+    }
+
+    public string ToBase62EncodedString() => ToString(BinaryStringEncoding.Base62);
+
+    public string ToBase64EncodedString() => ToString(BinaryStringEncoding.Base64);
+}

--- a/src/DSE.Open/BinaryValue.cs
+++ b/src/DSE.Open/BinaryValue.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json.Serialization;
 using DSE.Open.Text.Json.Serialization;
 
@@ -13,7 +12,7 @@ namespace DSE.Open;
 /// An immutable binary data value.
 /// </summary>
 [JsonConverter(typeof(JsonStringBinaryValueBase64Converter))]
-public readonly record struct BinaryValue
+public readonly partial record struct BinaryValue : ISpanFormattable, IUtf8SpanFormattable, IComparable<BinaryValue>
 {
     private readonly ReadOnlyMemory<byte> _value;
 
@@ -56,133 +55,14 @@ public readonly record struct BinaryValue
 
     public ReadOnlySpan<byte> AsSpan() => _value.Span;
 
-    public static BinaryValue FromBase62EncodedString(string value)
-        => FromEncodedString(value, BinaryStringEncoding.Base62);
-
-    public static BinaryValue FromBase64EncodedString(string value)
-        => FromEncodedString(value, BinaryStringEncoding.Base64);
-
-    public static BinaryValue FromEncodedString(string value, BinaryStringEncoding encoding)
-    {
-        return encoding == BinaryStringEncoding.Base62
-            ? new BinaryValue(Base62Converter.FromBase62(value), true)
-            : encoding is BinaryStringEncoding.HexLower or BinaryStringEncoding.HexUpper
-            ? new BinaryValue(Convert.FromHexString(value), true)
-            : new BinaryValue(Convert.FromBase64String(value), true);
-    }
-
-    public static BinaryValue FromString(string value, Encoding? encoding = null)
-    {
-        encoding ??= Encoding.UTF8;
-
-        return new BinaryValue(encoding.GetBytes(value), true);
-    }
-
-    public static bool TryFromBase62EncodedString(string value, out BinaryValue binaryValue)
-        => TryFromEncodedString(value, BinaryStringEncoding.Base62, out binaryValue);
-
-    public static bool TryFromBase64EncodedString(string value, out BinaryValue binaryValue)
-        => TryFromEncodedString(value, BinaryStringEncoding.Base64, out binaryValue);
-
-    public static bool TryFromEncodedString(string value, BinaryStringEncoding encoding, out BinaryValue binaryValue)
-    {
-        switch (encoding)
-        {
-            case BinaryStringEncoding.Base62 when Base62Converter.TryFromBase62(value, out var data):
-                binaryValue = new BinaryValue(data, true);
-                return true;
-            case BinaryStringEncoding.Base62:
-                binaryValue = default;
-                return false;
-            case BinaryStringEncoding.HexLower or BinaryStringEncoding.HexUpper:
-                try
-                {
-                    binaryValue = new BinaryValue(Convert.FromHexString(value), true);
-                    return true;
-                }
-                catch (FormatException)
-                {
-                }
-                catch (ArgumentNullException)
-                {
-                }
-
-                break;
-        }
-
-        try
-        {
-            binaryValue = new BinaryValue(Convert.FromBase64String(value), true);
-            return true;
-        }
-        catch (FormatException)
-        {
-        }
-        catch (ArgumentNullException)
-        {
-        }
-
-        binaryValue = default;
-        return false;
-    }
-
     /// <summary>
     /// Returns a copy of the value as an array.
     /// </summary>
-    /// <returns></returns>
     public byte[] ToArray() => _value.ToArray();
 
-    public bool Equals(BinaryValue other) =>  _value.Span.SequenceEqual(other._value.Span);
+    public bool Equals(BinaryValue other) => _value.Span.SequenceEqual(other._value.Span);
 
-    public bool TryFormat(Span<char> destination, out int charsWritten)
-        => TryFormat(destination, out charsWritten, null, null);
-
-    public bool TryFormat(
-        Span<char> destination,
-        out int charsWritten,
-        ReadOnlySpan<char> format,
-        IFormatProvider? provider)
-    {
-        if (_value.Length == 0)
-        {
-            charsWritten = 0;
-            return true;
-        }
-
-        var hex = ToString();
-
-        if (destination.Length >= hex.Length)
-        {
-            hex.AsSpan().CopyTo(destination);
-            charsWritten = hex.Length;
-            return true;
-        }
-
-        charsWritten = 0;
-        return false;
-    }
-
-    public override string ToString() => ToBase64EncodedString();
-
-    public string ToString(BinaryStringEncoding format)
-    {
-        return _value.Length == 0
-            ? string.Empty
-            : format switch
-            {
-                BinaryStringEncoding.Base62 => ToBase62EncodedString(),
-                BinaryStringEncoding.HexUpper => Convert.ToHexString(_value.Span),
-                _ => format == BinaryStringEncoding.HexLower
-                    ? Convert.ToHexString(_value.Span).ToLowerInvariant()
-                    : ToBase64EncodedString()
-            };
-    }
-
-    public string ToBase62EncodedString()
-        => _value.Length == 0 ? string.Empty : Base62Converter.ToBase62String(_value.Span);
-
-    public string ToBase64EncodedString()
-        => _value.Length == 0 ? string.Empty : Convert.ToBase64String(_value.Span);
+    public int CompareTo(BinaryValue other) => _value.Span.SequenceCompareTo(other._value.Span);
 
     public override int GetHashCode()
     {
@@ -223,13 +103,19 @@ public readonly record struct BinaryValue
         return new BinaryValue(buffer, true);
     }
 
-#pragma warning disable CA2225 // Operator overloads have named alternates
+    public static explicit operator ReadOnlyMemory<byte>(BinaryValue value) => value.AsMemory();
 
-    public static explicit operator ReadOnlyMemory<byte>(BinaryValue value) => value._value;
+    public static explicit operator ReadOnlySpan<byte>(BinaryValue value) => value.AsSpan();
 
-    public static explicit operator ReadOnlySpan<byte>(BinaryValue value) => value._value.Span;
+    internal static BinaryValue CreateUnsafe(byte[] bytes)
+    {
+        Guard.IsNotNull(bytes);
 
-#pragma warning restore CA2225 // Operator overloads have named alternates
+        if (bytes.Length == 0)
+        {
+            return Empty;
+        }
 
+        return new BinaryValue(bytes, noCopy: true);
+    }
 }
-

--- a/src/DSE.Open/HexConverter.cs
+++ b/src/DSE.Open/HexConverter.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace DSE.Open;
+
+// Uses some of the internals from
+// https://github.com/dotnet/runtime/blob/cfbd1816a02391e5dde739f9f353bd3fbda79cff/src/libraries/Common/src/System/HexConverter.cs#L17
+
+internal static class HexConverter
+{
+    internal enum Casing : uint
+    {
+        // Output [ '0' .. '9' ] and [ 'A' .. 'F' ].
+        Upper = 0,
+
+        // Output [ '0' .. '9' ] and [ 'a' .. 'f' ].
+        // This works because values in the range [ 0x30 .. 0x39 ] ([ '0' .. '9' ])
+        // already have the 0x20 bit set, so ORing them with 0x20 is a no-op,
+        // while outputs in the range [ 0x41 .. 0x46 ] ([ 'A' .. 'F' ])
+        // don't have the 0x20 bit set, so ORing them maps to
+        // [ 0x61 .. 0x66 ] ([ 'a' .. 'f' ]), which is what we want.
+        Lower = 0x2020U,
+    }
+
+    public static bool TryEncodeToHexLower(ReadOnlySpan<byte> data, Span<byte> utf8Destination, out int bytesWritten)
+        => TryEncodeToHex(data, utf8Destination, out bytesWritten, Casing.Lower);
+
+    public static bool TryEncodeToHexUpper(ReadOnlySpan<byte> data, Span<byte> utf8Destination, out int bytesWritten)
+        => TryEncodeToHex(data, utf8Destination, out bytesWritten, Casing.Upper);
+
+    private static bool TryEncodeToHex(ReadOnlySpan<byte> data, Span<byte> utf8Destination, out int bytesWritten, Casing casing)
+    {
+        for (var i = 0; i < data.Length; i++)
+        {
+            ToBytesBuffer(data[i], utf8Destination, i * 2, casing);
+        }
+
+        bytesWritten = data.Length * 2;
+        return true;
+    }
+
+    public static bool TryEncodeToHexLower(ReadOnlySpan<byte> data, Span<char> destination, out int charsWritten)
+        => TryEncodeToHex(data, destination, out charsWritten, Casing.Lower);
+
+    public static bool TryEncodeToHexUpper(ReadOnlySpan<byte> data, Span<char> destination, out int charsWritten)
+        => TryEncodeToHex(data, destination, out charsWritten, Casing.Upper);
+
+    private static bool TryEncodeToHex(ReadOnlySpan<byte> data, Span<char> destination, out int charsWritten, Casing casing)
+    {
+        Debug.Assert(destination.Length >= data.Length * 2);
+
+        for (var pos = 0; pos < data.Length; pos++)
+        {
+            ToCharsBuffer(data[pos], destination, pos * 2, casing);
+        }
+
+        charsWritten = data.Length * 2;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ToBytesBuffer(byte value, Span<byte> buffer, int startingIndex = 0, Casing casing = Casing.Upper)
+    {
+        var difference = (((uint)value & 0xF0U) << 4) + ((uint)value & 0x0FU) - 0x8989U;
+        var packedResult = ((((uint)(-(int)difference) & 0x7070U) >> 4) + difference + 0xB9B9U) | (uint)casing;
+
+        buffer[startingIndex + 1] = (byte)packedResult;
+        buffer[startingIndex] = (byte)(packedResult >> 8);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ToCharsBuffer(byte value, Span<char> buffer, int startingIndex = 0, Casing casing = Casing.Upper)
+    {
+        var difference = (((uint)value & 0xF0U) << 4) + ((uint)value & 0x0FU) - 0x8989U;
+        var packedResult = ((((uint)(-(int)difference) & 0x7070U) >> 4) + difference + 0xB9B9U) | (uint)casing;
+
+        buffer[startingIndex + 1] = (char)(packedResult & 0xFF);
+        buffer[startingIndex] = (char)(packedResult >> 8);
+    }
+
+    private const string UpperCaseHexChars = "0123456789ABCDEF";
+
+    private static ReadOnlySpan<byte> UpperCaseHexBytes => "0123456789ABCDEF"u8;
+
+    private const string LowerCaseHexChars = "0123456789abcdef";
+
+    private static ReadOnlySpan<byte> LowerCaseHexBytes => "0123456789abcdef"u8;
+
+    internal static bool IsValidLowerHex(ReadOnlySpan<char> source) => source.IndexOfAnyExcept(LowerCaseHexChars) < 0;
+
+    internal static bool IsValidUpperHex(ReadOnlySpan<char> source) => source.IndexOfAnyExcept(UpperCaseHexChars) < 0;
+
+    internal static bool IsValidLowerHex(ReadOnlySpan<byte> source) => source.IndexOfAnyExcept(LowerCaseHexBytes) < 0;
+
+    internal static bool IsValidUpperHex(ReadOnlySpan<byte> source) => source.IndexOfAnyExcept(UpperCaseHexBytes) < 0;
+
+    public static bool TryConvertFromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten)
+    {
+        if (source.Length % 2 != 0)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        var i = 0;
+        var j = 0;
+
+        while (i < source.Length)
+        {
+            var hi = CharToHexLookup[source[i++]];
+            var lo = CharToHexLookup[source[i++]];
+
+            if (hi == 0xFF || lo == 0xFF)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            destination[j++] = (byte)((hi << 4) | lo);
+        }
+
+        bytesWritten = j;
+        return true;
+    }
+
+
+    /// <summary>Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.</summary>
+    public static ReadOnlySpan<byte> CharToHexLookup => new byte[]
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 15
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 31
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 47
+        0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 63
+        0xFF, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 79
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 95
+        0xFF, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 111
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 127
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 143
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 159
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 175
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 191
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 207
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 223
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 239
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 255
+    };
+}

--- a/test/DSE.Open.Tests/Base62ConverterTests.cs
+++ b/test/DSE.Open.Tests/Base62ConverterTests.cs
@@ -2,17 +2,18 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using System.Security.Cryptography;
+using System.Text;
 
 namespace DSE.Open.Tests;
 
 public class Base62ConverterTests
 {
+    private readonly ITestOutputHelper _output;
+
     public Base62ConverterTests(ITestOutputHelper output)
     {
-        Output = output;
+        _output = output;
     }
-
-    public ITestOutputHelper Output { get; }
 
     [Fact]
     public void ToBase62String_FromBase62_roundtrip()
@@ -22,12 +23,71 @@ public class Base62ConverterTests
             var data = RandomNumberGenerator.GetBytes(8);
             var encoded = Base62Converter.ToBase62String(data);
 
-            Output.WriteLine($"{Convert.ToHexString(data)} {encoded}");
+            _output.WriteLine($"{Convert.ToHexString(data)} {encoded}");
 
             var decoded = Base62Converter.FromBase62(encoded);
 
             Assert.True(data.SequenceEqual(decoded));
         }
+    }
+
+    [Fact]
+    public void ToBase62_ShouldCorrectlyEncode()
+    {
+        foreach (var (text, base62) in s_validTestCases)
+        {
+            if (!Base62Converter.TryFromBase62(base62, out var data))
+            {
+                Assert.Fail("Failed to decode input");
+            }
+
+            var actual = Base62Converter.ToBase62String(data);
+
+            Assert.Equal(base62, actual);
+            Assert.Equal(text, Encoding.UTF8.GetString(data));
+        }
+    }
+
+    [Fact]
+    public void TryFromBase62_WithEmpty_ShouldReturnTrueAndEmpty()
+    {
+        // Arrange
+        var encoded = string.Empty;
+
+        // Act
+        var succeeded = Base62Converter.TryFromBase62(encoded, out var data);
+
+        // Assert
+        Assert.True(succeeded);
+        Assert.Empty(data);
+    }
+
+    [Fact]
+    public void TryFromBase62Chars_WithEmpty_ShouldReturnTrueAndEmpty()
+    {
+        // Arrange
+        ReadOnlySpan<char> encoded = string.Empty;
+
+        // Act
+        var succeeded = Base62Converter.TryFromBase62Chars(encoded, out var data);
+
+        // Assert
+        Assert.True(succeeded);
+        Assert.Empty(data);
+    }
+
+    [Fact]
+    public void TryFromBase62Chars_WithInvalidData_ShouldReturnFalse()
+    {
+        // Arrange
+        const string invalid = "!@#$%^&*()";
+
+        // Act
+        var succeeded = Base62Converter.TryFromBase62Chars(invalid, out var data);
+
+        // Assert
+        Assert.False(succeeded);
+        Assert.Empty(data);
     }
 
     [Theory]
@@ -37,4 +97,15 @@ public class Base62ConverterTests
         var succeeded = Base62Converter.TryFromBase62(encoded, out _);
         Assert.True(succeeded);
     }
+
+    private static readonly Dictionary<string, string> s_validTestCases = new()
+    {
+        { "a", "1Z" },
+        { "Z", "1S" },
+        { "Hello, world!", "1wJfrzvdbthTq5ANZB" },
+        {
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Amet nisl suscipit adipiscing bibendum est ultricies integer quis. Sed risus pretium quam vulputate. Lorem ipsum dolor sit amet consectetur adipiscing elit pellentesque habitant. Ultricies mi quis hendrerit dolor. Proin sed libero enim sed faucibus turpis in eu. Sed vulputate odio ut enim. Quis hendrerit dolor magna eget est lorem ipsum. Vestibulum lorem sed risus ultricies tristique nulla aliquet. Elementum pulvinar etiam non quam lacus suspendisse faucibus interdum.",
+            "7SV7pJHP2QYm18yr6naoggbJoylyTFryGTE5Q5kj58nU7A0mWg7J4A55C5qDmegD4Gp9P3AukZ3BjXfL9YnFlAcf73lxohbMKKERlljHdtmqW1jetkhaqMt6VEyBDFaR1Y3Pvd3ZsrIDV4164SZl5dkkFSGIQ1MXNTUUgzhExpo94XAz0OTobuqpTnZ8a8GLCT1y5p3KWjSH3k0l4FS26ZeJL5TahJqQ2fbKrBvZxn3vlekiuV5R5H9pMAfbcdce9jOJQBXjoMqysuw29PEavTOkK4yB3hMTjRDB0usdP5DMErbN468rxau2n3LasLmBoL1gJzKO8LHRhLYEdLrmACVyog5EWBcSHV2GCblTkr5OmO4RKQDQaZ4543FfH64tMfiRju4ValfqC346ULDdhqfWckE5DNNr4d08Do77HV4K5KnLND2JnpWkUPtBs8yjXGskPoEpgGeh0kLHqddLFdeSqqI84GiZzoinLIu8yawyAw4veClhexXVgX4Lyy3vabpd4witHLRMvDlU3hJIsY6f7FUcN0kwz4xMnMOjCoDjTJII3kmHm7G9I1JwVuNNJpqmriCqCoOmztA18HaKYhQIh4tduteaRvuD1rsAIlHQefoh52YNkeCLhYvIb7ZNqbgZkpc9J0boAf41rmZXwlKT5hkQLQPgZIngzqDLGgJxX1686KhAY3hUxGvUhZhFFKHQ65ud15ncqEYPFBeuteE3IH2qor7qiBVvp3jzrTyYgTHKrHC3o12COVVkEUdGvOtUauT7tpeiglFjsLpbPkGz8I2EiE8re"
+        }
+    };
 }

--- a/test/DSE.Open.Tests/BinaryValueTests.cs
+++ b/test/DSE.Open.Tests/BinaryValueTests.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
+using System.Text;
+using System.Text.Json;
+
 namespace DSE.Open.Tests;
 
 public class BinaryValueTests
 {
     [Fact]
-    public void To_from_base62()
+    public void Base62_RoundTrip_String()
     {
         for (var i = 0; i < 100; i++)
         {
@@ -18,7 +21,7 @@ public class BinaryValueTests
     }
 
     [Fact]
-    public void To_from_base64()
+    public void Base64_RoundTrip_String()
     {
         for (var i = 0; i < 100; i++)
         {
@@ -29,9 +32,171 @@ public class BinaryValueTests
         }
     }
 
+    [Fact]
+    public void HexLower_RoundTrip_String()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+            var encoded = value.ToString(BinaryStringEncoding.HexLower);
+            var value2 = BinaryValue.FromEncodedString(encoded, BinaryStringEncoding.HexLower);
+            Assert.Equal(value, value2);
+        }
+    }
+
+    [Fact]
+    public void HexUpper_RoundTrip_String()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+            var encoded = value.ToString(BinaryStringEncoding.HexUpper);
+            var value2 = BinaryValue.FromEncodedString(encoded, BinaryStringEncoding.HexUpper);
+            Assert.Equal(value, value2);
+        }
+    }
+
+    [Fact]
+    public void Base62_RoundTrip_Chars()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+
+            var requiredLength = BinaryValue.GetRequiredBufferSize(value.Length, BinaryStringEncoding.Base62);
+
+            var buffer = new char[requiredLength];
+
+            var success = value.TryFormat(buffer, out var charsWritten, format: "b", provider: default);
+
+            Assert.True(success);
+
+            var value2 = BinaryValue.FromEncodedString(buffer.AsSpan(0, charsWritten).ToString(), BinaryStringEncoding.Base62);
+
+            Assert.Equal(value, value2);
+        }
+    }
+
+    [Fact]
+    public void Base64_RoundTrip_Chars()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+
+            var requiredLength = BinaryValue.GetRequiredBufferSize(value.Length, BinaryStringEncoding.Base64);
+
+            var buffer = new char[requiredLength];
+
+            var success = value.TryFormat(buffer, out var charsWritten, format: "B", provider: default);
+
+            Assert.True(success);
+
+            var value2 = BinaryValue.FromEncodedString(buffer.AsSpan(0, charsWritten).ToString(), BinaryStringEncoding.Base64);
+
+            Assert.Equal(value, value2);
+        }
+    }
+
+
+    [Fact]
+    public void Base64_RoundTrip_Bytes()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+
+            var requiredLength = BinaryValue.GetRequiredBufferSize(value.Length, BinaryStringEncoding.Base64);
+
+            var buffer = new byte[requiredLength];
+
+            var success = value.TryFormat(buffer, out var bytesWritten, format: "B", provider: default);
+
+            Assert.True(success);
+
+            var fromSuccess = BinaryValue.TryFromEncodedBytes(buffer.AsSpan(0, bytesWritten), BinaryStringEncoding.Base64, out var value2);
+
+            Assert.True(fromSuccess);
+            Assert.Equal(value, value2);
+        }
+    }
+
+    [Fact]
+    public void HexLower_RoundTrip_Chars()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+
+            var requiredLength = BinaryValue.GetRequiredBufferSize(value.Length, BinaryStringEncoding.HexLower);
+
+            var buffer = new char[requiredLength];
+
+            var success = value.TryFormat(buffer, out var charsWritten, format: "x", provider: default);
+
+            Assert.True(success);
+
+            var value2 = BinaryValue.FromEncodedString(buffer.AsSpan(0, charsWritten).ToString(), BinaryStringEncoding.HexLower);
+
+            Assert.Equal(value, value2);
+        }
+    }
+
+    [Fact]
+    public void FromHexBytes_WithValidHex_ShouldReturnCorrectData_Lower()
+    {
+        // Arrange
+        var hex = "48656c6c6f2c20576f726c6421"u8; // "Hello, World!"
+
+        // Act
+        var result = BinaryValue.TryFromEncodedBytes(hex, BinaryStringEncoding.HexLower, out var decoded);
+        var decodedHex = decoded.ToString(BinaryStringEncoding.HexLower);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(Encoding.UTF8.GetString(hex), decodedHex);
+        Assert.True("Hello, World!"u8.SequenceEqual(Convert.FromHexString(decoded.ToString(BinaryStringEncoding.HexLower))));
+    }
+
+
+    [Fact]
+    public void FromHexBytes_WithValidHex_ShouldReturnCorrectData_Upper()
+    {
+        // Arrange
+        var hex = "48656C6C6F2C20576F726C6421"u8; // "Hello, World!"
+
+        // Act
+        var result = BinaryValue.TryFromEncodedBytes(hex, BinaryStringEncoding.HexUpper, out var decoded);
+        var decodedHex = decoded.ToString(BinaryStringEncoding.HexUpper);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(Encoding.UTF8.GetString(hex), decodedHex);
+        Assert.True("Hello, World!"u8.SequenceEqual(Convert.FromHexString(decodedHex)));
+    }
+
+    [Fact]
+    public void HexUpper_RoundTrip_Chars()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var value = BinaryValue.GetRandomValue();
+
+            var requiredLength = BinaryValue.GetRequiredBufferSize(value.Length, BinaryStringEncoding.HexUpper);
+
+            var buffer = new char[requiredLength];
+
+            var success = value.TryFormat(buffer, out var charsWritten, format: "X", provider: default);
+
+            Assert.True(success);
+
+            var value2 = BinaryValue.FromEncodedString(buffer.AsSpan(0, charsWritten).ToString(), BinaryStringEncoding.HexUpper);
+
+            Assert.Equal(value, value2);
+        }
+    }
+
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
     [InlineData("in/valid")]
     [InlineData("i~nvalid")]
     [InlineData("invalid*")]
@@ -55,5 +220,123 @@ public class BinaryValueTests
     {
         var succeeded = BinaryValue.TryFromEncodedString(encoded, BinaryStringEncoding.Base62, out _);
         Assert.True(succeeded);
+    }
+
+    [Fact]
+    public void TryFromBase64String_WithValidData_ShouldReturnTrue()
+    {
+        // Arrange
+        var value = BinaryValue.GetRandomValue();
+        var encoded = value.ToBase64EncodedString();
+
+        // Act
+        var result = BinaryValue.TryFromBase64EncodedString(encoded, out var decoded);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(value, decoded);
+    }
+
+    [Fact]
+    public void TryFromHexLowerString_WithWithValidData_ShouldReturnTrue()
+    {
+        // Arrange
+        var value = BinaryValue.GetRandomValue();
+        var encoded = value.ToString(BinaryStringEncoding.HexLower);
+
+        // Act
+        var result = BinaryValue.TryFromEncodedString(encoded, BinaryStringEncoding.HexLower, out var decoded);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(value, decoded);
+    }
+
+    [Fact]
+    public void TryFromHexUpperString_WithValidData_ShouldReturnTrue()
+    {
+        // Arrange
+        var value = BinaryValue.GetRandomValue();
+        var encoded = value.ToString(BinaryStringEncoding.HexUpper);
+
+        // Act
+        var result = BinaryValue.TryFromEncodedString(encoded, BinaryStringEncoding.HexUpper, out var decoded);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(value, decoded);
+    }
+
+    [Fact]
+    public void ToString_WithNoArguments_ShouldFormatAsBase64()
+    {
+        // Arrange
+        const string base64 = "SGVsbG8gV29ybGQh"; // "Hello World!"
+        var value = BinaryValue.FromEncodedString("Hello World!");
+
+        // Act
+        var result = value.ToString();
+
+        // Assert
+        Assert.Equal(base64, result);
+    }
+
+    [Fact]
+    public void Serialize_ShouldFormatAsBase64()
+    {
+        // Arrange
+        const string base64 = "SGVsbG8gV29ybGQh"; // "Hello World!"
+        var value = BinaryValue.FromEncodedString("Hello World!");
+
+        // Act
+        var result = JsonSerializer.Serialize(value);
+
+        // Assert
+        Assert.Equal($"\"{base64}\"", result);
+    }
+
+    [Fact]
+    public void JsonSerialize_ShouldBeRoundtrippable()
+    {
+        // Arrange
+        var value = BinaryValue.GetRandomValue();
+
+        // Act
+        var json = JsonSerializer.Serialize(value);
+        var deserialized = JsonSerializer.Deserialize<BinaryValue>(json);
+
+        // Assert
+        Assert.Equal(value, deserialized);
+    }
+
+    [Fact]
+    public void TryFormat_WithNoFormatString_ShouldFormatAsBase64()
+    {
+        // Arrange
+        var value = BinaryValue.FromEncodedString("Hello World!");
+        var buffer = new char[12 + 4]; // "Hello World!" + padding
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, format: default, provider: default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(16, charsWritten);
+        Assert.True(buffer.AsSpan() is "SGVsbG8gV29ybGQh");
+    }
+
+    [Fact]
+    public void ToString_WithNoFormat_ShouldFormatAsBase64()
+    {
+        // Arrange
+        var value = BinaryValue.FromEncodedString("Hello World!");
+        var buffer = new char[12 + 4]; // "Hello World!" + padding
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, format: default, provider: default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(16, charsWritten);
     }
 }

--- a/test/DSE.Open.Tests/HexConverterTests.cs
+++ b/test/DSE.Open.Tests/HexConverterTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text;
+
+namespace DSE.Open.Tests;
+
+public class HexConverterTests
+{
+    [Fact]
+    public void TryEncodeToHex_WithValidBytesData_ShouldReturnTrue_Upper()
+    {
+        // Arrange
+        ReadOnlySpan<byte> data = stackalloc byte[] { 0x0 };
+        var buffer = new byte[2];
+
+        // Act
+        var result = HexConverter.TryEncodeToHexUpper(data, buffer, out var bytesWritten);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(2, bytesWritten);
+        Assert.Equal("00", Encoding.ASCII.GetString(buffer));
+    }
+
+    [Fact]
+    public void TryEncodeToHex_WithValidCharsData_ShouldReturnTrue_Upper()
+    {
+        // Arrange
+        ReadOnlySpan<byte> data = stackalloc byte[] { 0x0 };
+        var buffer = new char[2];
+
+        // Act
+        var result = HexConverter.TryEncodeToHexUpper(data, buffer, out var charsWritten);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(2, charsWritten);
+        Assert.Equal("00", new string(buffer));
+    }
+
+    [Fact]
+    public void TryEncodeToHex_WithValidBytesData_ShouldReturnTrue_Lower()
+    {
+        // Arrange
+        ReadOnlySpan<byte> data = stackalloc byte[] { 0x0 };
+        var buffer = new byte[2];
+
+        // Act
+        var result = HexConverter.TryEncodeToHexLower(data, buffer, out var bytesWritten);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(2, bytesWritten);
+        Assert.Equal("00", Encoding.ASCII.GetString(buffer));
+    }
+
+    [Fact]
+    public void TryEncodeToHex_WithValidCharsData_ShouldReturnTrue_Lower()
+    {
+        // Arrange
+        ReadOnlySpan<byte> data = stackalloc byte[] { 0x0 };
+        var buffer = new char[2];
+
+        // Act
+        var result = HexConverter.TryEncodeToHexLower(data, buffer, out var charsWritten);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(2, charsWritten);
+        Assert.Equal("00", new string(buffer));
+    }
+}


### PR DESCRIPTION
## JSON

Nice speedup and reduction in allocations for JSON round trip.

| Method         |     Mean |   Error |  StdDev | Allocated |
| -------------- | -------: | ------: | ------: | --------: |
| RoundTrip_Main | 200.9 ns | 0.34 ns | 0.32 ns |     240 B |
| RoundTrip_PR   | 158.0 ns | 0.43 ns | 0.36 ns |     112 B |

### PR

Deserialize now only allocates the number of bytes needed for the backing store.

| Method      | Mean     | Error    | StdDev   | Allocated |
|------------ |---------:|---------:|---------:|----------:|
| Serialize   | 77.32 ns | 0.204 ns | 0.181 ns |      72 B |
| Deserialize | 75.70 ns | 0.190 ns | 0.178 ns |      40 B |

## Formatting

### Base64 (default)

#### Main

| Method                |     Mean |    Error |   StdDev | Allocated |
| --------------------- | -------: | -------: | -------: | --------: |
| ToBase64String        | 14.83 ns | 0.092 ns | 0.077 ns |      64 B |
| TryFormatBase64_Chars | 16.06 ns | 0.050 ns | 0.047 ns |      64 B |

#### PR

| Method                |       Mean |     Error |    StdDev | Allocated |
| --------------------- | ---------: | --------: | --------: | --------: |
| ToBase64String        | 14.8255 ns | 0.0528 ns | 0.0494 ns |      64 B |
| TryFormatBase64_Chars |  0.1807 ns | 0.0040 ns | 0.0035 ns |         - |
| TryFormatBase64_Bytes |  9.2712 ns | 0.0221 ns | 0.0184 ns |         - |

```cs
[MemoryDiagnoser(displayGenColumns: false)]
public class BinaryValueToBase64Benchmarks
{
    private static readonly BinaryValue s_value = BinaryValue.FromString("Hello, World!");

    [Benchmark]
    public string ToBase64String() => s_value.ToBase64EncodedString();

    [Benchmark]
    public bool TryFormatBase64_Chars()
    {
        Span<char> buffer = stackalloc char[16];
        return s_value.TryFormat(buffer, out _, format: default, provider: default);
    }

    [Benchmark]
    public bool TryFormatBase64_Bytes()
    {
        Span<byte> buffer = stackalloc byte[16];
        return s_value.TryFormat(buffer, out _, format: default, provider: default);
    }
}
```

### Hex

#### Main

| Method           |     Mean |    Error |   StdDev | Allocated |
| ---------------- | -------: | -------: | -------: | --------: |
| ToHexLowerString | 26.53 ns | 0.047 ns | 0.041 ns |     160 B |
| ToHexUpperString | 11.11 ns | 0.151 ns | 0.142 ns |      80 B |

#### PR

| Method                  |     Mean |    Error |   StdDev | Allocated |
| ----------------------- | -------: | -------: | -------: | --------: |
| ToHexLowerString        | 16.59 ns | 0.291 ns | 0.273 ns |      80 B |
| ToHexUpperString        | 16.88 ns | 0.176 ns | 0.156 ns |      80 B |
|                         |          |          |          |           |
| TryFormatHexLower_Chars | 11.81 ns | 0.014 ns | 0.013 ns |         - |
| TryFormatHexUpper_Chars | 12.04 ns | 0.108 ns | 0.101 ns |         - |
|                         |          |          |          |           |
| TryFormatHexLower_Bytes | 17.94 ns | 0.034 ns | 0.030 ns |         - |
| TryFormatHexUpper_Bytes | 17.47 ns | 0.060 ns | 0.057 ns |         - |

## Creating

Creating was already calling off to the various `Convert` methods, so no perf gains when creating from encoded strings.

#### Main

| Method                  |       Mean |     Error |    StdDev | Allocated |
| ----------------------- | ---------: | --------: | --------: | --------: |
| FromBase62EncodedString | 512.566 ns | 1.6935 ns | 1.4141 ns |    1304 B |
| FromBase64EncodedString |  24.773 ns | 0.0531 ns | 0.0443 ns |      40 B |
| FromHexLowerString      |   9.380 ns | 0.0325 ns | 0.0304 ns |      40 B |
| FromHexUpperString      |   9.420 ns | 0.0220 ns | 0.0195 ns |      40 B |

#### PR

| Method                  |       Mean |     Error |    StdDev | Allocated |
| ----------------------- | ---------: | --------: | --------: | --------: |
| FromBase62EncodedString | 508.442 ns | 1.6548 ns | 1.5479 ns |    1304 B |
| FromBase64EncodedString |  24.905 ns | 0.0314 ns | 0.0262 ns |      40 B |
| FromHexLowerString      |   9.535 ns | 0.0398 ns | 0.0332 ns |      40 B |
| FromHexUpperString      |   9.573 ns | 0.0586 ns | 0.0548 ns |      40 B |

| Method                 |      Mean |    Error |   StdDev | Allocated |
| ---------------------- | --------: | -------: | -------: | --------: |
| FromBase62EncodedChars | 508.54 ns | 1.373 ns | 1.285 ns |    1304 B |
| FromBase64EncodedChars |  18.60 ns | 0.052 ns | 0.048 ns |      40 B |
| FromHexUpperChars      |  23.42 ns | 0.084 ns | 0.070 ns |      40 B |
| FromHexLowerChars      |  23.42 ns | 0.068 ns | 0.064 ns |      40 B |

| Method                 |      Mean |    Error |   StdDev | Allocated |
| ---------------------- | --------: | -------: | -------: | --------: |
| FromBase62EncodedBytes | 522.26 ns | 1.444 ns | 1.351 ns |    1368 B |
| FromBase64EncodedBytes |  15.70 ns | 0.045 ns | 0.042 ns |      40 B |
| FromHexUpperBytes      |  21.69 ns | 0.138 ns | 0.129 ns |      40 B |
| FromHexLowerBytes      |  21.67 ns | 0.043 ns | 0.040 ns |      40 B |
