### PR TITLE
Update current collection builders

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/Collections/ReadOnlyValueCollectionCreateBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Collections/ReadOnlyValueCollectionCreateBenchmarks.cs
@@ -1,0 +1,43 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using DSE.Open.Collections.Generic;
+
+namespace DSE.Open.Benchmarks.Collections;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(false)]
+public class ReadOnlyValueCollectionCreateBenchmarks
+{
+    public const int N = 100;
+
+    private static readonly List<int> s_items = new(N);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            s_items.Add(i);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public ReadOnlyValueCollection<int> Create_IEnumerable()
+    {
+        return ReadOnlyValueCollection.CreateRange(s_items);
+    }
+
+    [Benchmark]
+    public ReadOnlyValueCollection<int> Create_Span()
+    {
+        var span = CollectionsMarshal.AsSpan(s_items);
+        return ReadOnlyValueCollection.Create(span);
+    }
+
+    [Benchmark]
+    public ReadOnlyValueCollection<int> Create_Unsafe()
+    {
+        return ReadOnlyValueCollection.CreateUnsafe(s_items);
+    }
+}

--- a/benchmarks/DSE.Open.Benchmarks/Collections/ReadOnlyValueSetCreateBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Collections/ReadOnlyValueSetCreateBenchmarks.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using DSE.Open.Collections.Generic;
+
+namespace DSE.Open.Benchmarks.Collections;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(false)]
+public class ReadOnlyValueSetCreateBenchmarks
+{
+    public const int N = 100;
+
+    private static readonly List<int> s_items = new(N);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        for (var i = 0; i < N; i++)
+        {
+            s_items.Add(i);
+        }
+    }
+
+    [Benchmark]
+    public ReadOnlyValueSet<int> Create_Span()
+    {
+        var span = CollectionsMarshal.AsSpan(s_items);
+        return ReadOnlyValueSet.Create<int>(span);
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,8 +7,9 @@ coverage:
       default:
         target: auto
         threshold: 1%
-        paths: 
+        paths:
           - "src"
           - "gen"
 ignore:
   - "test"
+  - "benchmarks"

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection.cs
@@ -21,7 +21,10 @@ public static class ReadOnlyValueCollection
             return ReadOnlyValueCollection<T>.Empty;
         }
 
-        return new ReadOnlyValueCollection<T>(items.ToArray());
+        var list = new List<T>(items.Length);
+        list.AddRange(items);
+
+        return CreateUnsafe(list);
     }
 
     /// <summary>

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace DSE.Open.Collections.Generic;
@@ -42,6 +43,19 @@ public class ReadOnlyValueCollection<T>
     {
         _items = items;
     }
+
+    /// <summary>
+    /// Provides a method for derived types to directly set the backing store. <paramref name="noCopy"/> must be <c>true</c>.
+    /// </summary>
+    /// <param name="items">The list to use as the backing store.</param>
+    /// <param name="noCopy">Must be true.</param>
+#pragma warning disable CA1002 // Do not expose generic lists
+    protected ReadOnlyValueCollection(List<T> items, bool noCopy)
+    {
+        Debug.Assert(noCopy);
+        _items = items;
+    }
+#pragma warning restore CA1002 // Do not expose generic lists
 
     public int Count => _items.Count;
 

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueSet.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueSet.cs
@@ -15,5 +15,20 @@ public static class ReadOnlyValueSet
     /// <param name="items">The elements to store in the set.</param>
     /// <returns>A <see cref="ReadOnlyValueSet{T}"/> containing the specified items.</returns>
     public static ReadOnlyValueSet<T> Create<T>(ReadOnlySpan<T> items)
-        => items.IsEmpty ? ReadOnlyValueSet<T>.Empty : new ReadOnlyValueSet<T>(items.ToArray());
+    {
+        if (items.IsEmpty)
+        {
+            return ReadOnlyValueSet<T>.Empty;
+        }
+
+        var set = new HashSet<T>(items.Length);
+
+        foreach (var item in items)
+        {
+            _ = set.Add(item);
+        }
+
+        return new ReadOnlyValueSet<T>(set);
+    }
+
 }

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueSet{T}.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueSet{T}.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace DSE.Open.Collections.Generic;
@@ -28,6 +29,17 @@ public class ReadOnlyValueSet<T> : IReadOnlySet<T>, IEquatable<ReadOnlyValueSet<
     [EditorBrowsable(EditorBrowsableState.Never)]
     internal ReadOnlyValueSet(HashSet<T> set)
     {
+        _set = set;
+    }
+
+    /// <summary>
+    /// Provides a method for derived types to directly set the backing store. <paramref name="noCopy"/> must be <c>true</c>.
+    /// </summary>
+    /// <param name="set">The set to use as the backing store.</param>
+    /// <param name="noCopy">Must be true.</param>
+    protected ReadOnlyValueSet(HashSet<T> set, bool noCopy)
+    {
+        Debug.Assert(noCopy);
         _set = set;
     }
 


### PR DESCRIPTION
Not sure I read through what I wrote last time 😟 Oops.

Second commit adds a way for derived types to write directly to the backing store (required for efficient collection builder implementations on their types)

## ReadOnlyValueCollection

| Method             | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|------------------- |----------:|----------:|----------:|------:|----------:|------------:|
| Create_IEnumerable | 37.070 ns | 0.1301 ns | 0.1016 ns |  1.00 |     480 B |        1.00 |
| Create_Span        | 67.331 ns | 0.4108 ns | 0.3641 ns |  1.82 |     904 B |        1.88 |
| Create_Unsafe      |  4.246 ns | 0.1152 ns | 0.1078 ns |  0.11 |      24 B |        0.05 |

| Method             | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|------------------- |----------:|----------:|----------:|------:|----------:|------------:|
| Create_IEnumerable | 36.816 ns | 0.2284 ns | 0.2137 ns |  1.00 |     480 B |        1.00 |
| Create_Span        | 35.324 ns | 0.1074 ns | 0.1004 ns |  0.96 |     480 B |        1.00 |
| Create_Unsafe      |  4.108 ns | 0.0285 ns | 0.0238 ns |  0.11 |      24 B |        0.05 |

## ReadOnlyValueSet

| Method      | Mean     | Error   | StdDev  | Allocated |
|------------ |---------:|--------:|--------:|----------:|
| Create_Span | 577.6 ns | 4.58 ns | 4.06 ns |   2.26 KB |
| Create_Span_PR | 463.9 ns | 2.06 ns | 1.72 ns |   1.81 KB |

