### PR TITLE
Call the convertible types `ToString`

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/Values/IdentifierToStringBenchmarks.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/IdentifierToStringBenchmarks.cs
@@ -1,0 +1,16 @@
+
+using BenchmarkDotNet.Attributes;
+using DSE.Open.Values;
+
+namespace DSE.Open.Benchmarks.Values;
+
+#pragma warning disable CA1822 // Mark members as static
+
+[MemoryDiagnoser(displayGenColumns: false)]
+public class IdentifierToStringBenchmarks
+{
+    private static readonly Identifier s_identifier = Identifier.Parse("dse_sub_VjHlsZTVmKRGglRRjSkPeQL71M17c7sQ"u8, null);
+
+    [Benchmark]
+    public string ToString_Default() => s_identifier.ToString();
+}

--- a/gen/DSE.Open.Values.Generators/Extensions/MethodDeclarationSyntaxExtensions.cs
+++ b/gen/DSE.Open.Values.Generators/Extensions/MethodDeclarationSyntaxExtensions.cs
@@ -18,6 +18,27 @@ internal static class MethodDeclarationSyntaxExtensions
         public const string Parse = "Parse";
     }
 
+    // public string ToString(string? format, IFormatProvider? provider);
+    public static bool IsIFormattableToStringMethod(this MethodDeclarationSyntax s)
+    {
+        if (s.Identifier.Text != "ToString")
+        {
+            return false;
+        }
+
+        return s.ParameterList.Parameters.Count == 2
+               && s.ParameterList.Parameters[0] is ParameterSyntax ps0
+               && ps0.Type is NullableTypeSyntax nts0
+               && nts0.ElementType is PredefinedTypeSyntax pts0
+               && pts0.Keyword.Text == "string"
+               && ps0.Identifier.ValueText == "format"
+               && s.ParameterList.Parameters[1] is ParameterSyntax ps1
+               && ps1.Type is NullableTypeSyntax nts1
+               && nts1.ElementType is IdentifierNameSyntax ins1
+               && ins1.Identifier.Text == "IFormatProvider"
+               && ps1.Identifier.ValueText == "provider";
+    }
+
     // public static bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
     public static bool IsISpanFormattableTryFormatMethod(this MethodDeclarationSyntax s)
     {

--- a/gen/DSE.Open.Values.Generators/ValueTypesGenerator.cs
+++ b/gen/DSE.Open.Values.Generators/ValueTypesGenerator.cs
@@ -415,6 +415,7 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
             var emitGetHashCodeMethod = true;
             var emitTryFormatMethod = true;
             var emitToStringOverrideMethod = true;
+            var emitIFormattableToStringMethod = true;
 
             foreach (var method in instanceMethods)
             {
@@ -475,10 +476,27 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
 
                 // ToString
 
-                if (emitToStringOverrideMethod && method.Identifier.ValueText == TargetNames.ToStringMethodName)
+                if (method.Identifier.ValueText == TargetNames.ToStringMethodName)
                 {
-                    emitToStringOverrideMethod = method.ParameterList.Parameters.Count != 0;
-                    continue;
+                    if (emitToStringOverrideMethod)
+                    {
+                        emitToStringOverrideMethod = method.ParameterList.Parameters.Count != 0;
+
+                        if (!emitToStringOverrideMethod)
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (emitIFormattableToStringMethod)
+                    {
+                        emitIFormattableToStringMethod = !method.IsIFormattableToStringMethod();
+
+                        if (!emitIFormattableToStringMethod)
+                        {
+                            continue;
+                        }
+                    }
                 }
             }
 
@@ -526,7 +544,11 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
             spec.EmitConstructor = emitConstructor;
             spec.EmitEqualsMethod = emitEqualsMethod;
             spec.EmitGetHashCodeMethod = emitGetHashCodeMethod;
+
+            // IFormattable
+            spec.EmitToStringFormatableMethod = emitIFormattableToStringMethod;
             spec.EmitTryFormatMethod = emitTryFormatMethod;
+
             spec.EmitToStringOverrideMethod = emitToStringOverrideMethod;
 
             spec.UseGetString = useGetStringMethod;
@@ -537,6 +559,7 @@ public sealed partial class ValueTypesGenerator : IIncrementalGenerator
                 spec.MaxSerializedCharLength = maxSerializedCharLength;
             }
 
+            // IUtf8SpanSerializable
             spec.EmitUtf8SpanSerializableInterface = emitUtf8SpanSerializableInterface;
             spec.EmitTryFormatUtf8Method = emitTryFormatUtf8Method;
             spec.EmitParseUtf8Method = emitParseUtf8Method;

--- a/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode.g.cs
+++ b/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode.g.cs
@@ -113,36 +113,15 @@ public readonly partial struct CountryCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the CountryCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="CountryCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the CountryCode value.
+    /// A representation of the <see cref="CountryCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode3.g.cs
+++ b/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/CountryCode3.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct CountryCode3
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the CountryCode3 value as a string with formatting options.
+    /// Gets a representation of the <see cref="CountryCode3"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the CountryCode3 value.
+    /// A representation of the <see cref="CountryCode3"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageCode2.g.cs
+++ b/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageCode2.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct LanguageCode2
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the LanguageCode2 value as a string with formatting options.
+    /// Gets a representation of the <see cref="LanguageCode2"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the LanguageCode2 value.
+    /// A representation of the <see cref="LanguageCode2"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
+++ b/src/DSE.Open.Globalization/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/LanguageTag.g.cs
@@ -103,10 +103,10 @@ public readonly partial struct LanguageTag
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the LanguageTag value as a string with formatting options.
+    /// Gets a representation of the <see cref="LanguageTag"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the LanguageTag value.
+    /// A representation of the <see cref="LanguageTag"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/SignKnowledge.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/SignKnowledge.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct SignKnowledge
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the SignKnowledge value as a string with formatting options.
+    /// Gets a representation of the <see cref="SignKnowledge"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the SignKnowledge value.
+    /// A representation of the <see cref="SignKnowledge"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/SignModality.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/SignModality.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct SignModality
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the SignModality value as a string with formatting options.
+    /// Gets a representation of the <see cref="SignModality"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the SignModality value.
+    /// A representation of the <see cref="SignModality"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/TreebankPosTag.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/TreebankPosTag.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct TreebankPosTag
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the TreebankPosTag value as a string with formatting options.
+    /// Gets a representation of the <see cref="TreebankPosTag"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the TreebankPosTag value.
+    /// A representation of the <see cref="TreebankPosTag"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UniversalPosTag.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UniversalPosTag.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct UniversalPosTag
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the UniversalPosTag value as a string with formatting options.
+    /// Gets a representation of the <see cref="UniversalPosTag"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the UniversalPosTag value.
+    /// A representation of the <see cref="UniversalPosTag"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UniversalSyntacticRelation.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UniversalSyntacticRelation.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct UniversalSyntacticRelation
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the UniversalSyntacticRelation value as a string with formatting options.
+    /// Gets a representation of the <see cref="UniversalSyntacticRelation"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the UniversalSyntacticRelation value.
+    /// A representation of the <see cref="UniversalSyntacticRelation"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Word.g.cs
+++ b/src/DSE.Open.Language.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Word.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct Word
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the Word value as a string with formatting options.
+    /// Gets a representation of the <see cref="Word"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the Word value.
+    /// A representation of the <see cref="Word"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Observations.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/YesNo.g.cs
+++ b/src/DSE.Open.Observations.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/YesNo.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct YesNo
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the YesNo value as a string with formatting options.
+    /// Gets a representation of the <see cref="YesNo"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the YesNo value.
+    /// A representation of the <see cref="YesNo"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Observations.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/YesNoUnsure.g.cs
+++ b/src/DSE.Open.Observations.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/YesNoUnsure.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct YesNoUnsure
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the YesNoUnsure value as a string with formatting options.
+    /// Gets a representation of the <see cref="YesNoUnsure"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the YesNoUnsure value.
+    /// A representation of the <see cref="YesNoUnsure"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/BiologicalSex.g.cs
+++ b/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/BiologicalSex.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct BiologicalSex
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the BiologicalSex value as a string with formatting options.
+    /// Gets a representation of the <see cref="BiologicalSex"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the BiologicalSex value.
+    /// A representation of the <see cref="BiologicalSex"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ClinicalConceptCode.g.cs
+++ b/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ClinicalConceptCode.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct ClinicalConceptCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the ClinicalConceptCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="ClinicalConceptCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the ClinicalConceptCode value.
+    /// A representation of the <see cref="ClinicalConceptCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ConditionDiagnosisCode.g.cs
+++ b/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ConditionDiagnosisCode.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct ConditionDiagnosisCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the ConditionDiagnosisCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="ConditionDiagnosisCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the ConditionDiagnosisCode value.
+    /// A representation of the <see cref="ConditionDiagnosisCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Gender.g.cs
+++ b/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Gender.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct Gender
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the Gender value as a string with formatting options.
+    /// Gets a representation of the <see cref="Gender"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the Gender value.
+    /// A representation of the <see cref="Gender"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/HearingDiagnosisCode.g.cs
+++ b/src/DSE.Open.Records.Abstractions/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/HearingDiagnosisCode.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct HearingDiagnosisCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the HearingDiagnosisCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="HearingDiagnosisCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the HearingDiagnosisCode value.
+    /// A representation of the <see cref="HearingDiagnosisCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Values/Identifier.cs
+++ b/src/DSE.Open.Values/Identifier.cs
@@ -204,7 +204,6 @@ public readonly partial struct Identifier : IEquatableValue<Identifier, AsciiStr
         return new Identifier(id);
     }
 
-
     /// <summary>
     /// Determines whether this <see cref="Identifier"/> starts with the given sequence of characters.
     /// </summary>

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaCode.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaCode.g.cs
@@ -121,10 +121,10 @@ public readonly partial struct AlphaCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the AlphaCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="AlphaCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the AlphaCode value.
+    /// A representation of the <see cref="AlphaCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaNumericCode.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/AlphaNumericCode.g.cs
@@ -121,10 +121,10 @@ public readonly partial struct AlphaNumericCode
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the AlphaNumericCode value as a string with formatting options.
+    /// Gets a representation of the <see cref="AlphaNumericCode"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the AlphaNumericCode value.
+    /// A representation of the <see cref="AlphaNumericCode"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ContainsPattern.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/ContainsPattern.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct ContainsPattern
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the ContainsPattern value as a string with formatting options.
+    /// Gets a representation of the <see cref="ContainsPattern"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the ContainsPattern value.
+    /// A representation of the <see cref="ContainsPattern"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Identifier.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Identifier.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct Identifier
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the Identifier value as a string with formatting options.
+    /// Gets a representation of the <see cref="Identifier"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the Identifier value.
+    /// A representation of the <see cref="Identifier"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Percent.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Percent.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct Percent
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the Percent value as a string with formatting options.
+    /// Gets a representation of the <see cref="Percent"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the Percent value.
+    /// A representation of the <see cref="Percent"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Ratio.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/Ratio.g.cs
@@ -121,36 +121,15 @@ public readonly partial struct Ratio
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the Ratio value as a string with formatting options.
+    /// Gets a representation of the <see cref="Ratio"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the Ratio value.
+    /// A representation of the <see cref="Ratio"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var maxCharLength = MaxSerializedCharLength;
-    
-        char[]? rented = null;
-    
-        try
-        {
-            Span<char> buffer = maxCharLength <= 128
-                ? stackalloc char[maxCharLength]
-                : (rented = System.Buffers.ArrayPool<char>.Shared.Rent(maxCharLength));
-    
-            _ = TryFormat(buffer, out var charsWritten, format, formatProvider);
-    
-            ReadOnlySpan<char> returnValue = buffer[..charsWritten];
-            return new string(returnValue);
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
-    
+        EnsureInitialized();    
+        return _value.ToString(format, formatProvider);
     }
 
     public string ToStringInvariant(string? format)

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriAsciiPath.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriAsciiPath.g.cs
@@ -121,10 +121,10 @@ public readonly partial struct UriAsciiPath
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the UriAsciiPath value as a string with formatting options.
+    /// Gets a representation of the <see cref="UriAsciiPath"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the UriAsciiPath value.
+    /// A representation of the <see cref="UriAsciiPath"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {

--- a/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriPath.g.cs
+++ b/src/DSE.Open.Values/gen/net8.0/DSE.Open.Values.Generators/DSE.Open.Values.Generators.ValueTypesGenerator/UriPath.g.cs
@@ -121,10 +121,10 @@ public readonly partial struct UriPath
         => TryFormatInvariant(destination, out charsWritten, default);
 
     /// <summary>
-    /// Gets a representation of the UriPath value as a string with formatting options.
+    /// Gets a representation of the <see cref="UriPath"/> value as a string with formatting options.
     /// </summary>
     /// <returns>
-    /// A representation of the UriPath value.
+    /// A representation of the <see cref="UriPath"/> value.
     /// </returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {


### PR DESCRIPTION
The source generator was outputting span buffers, etc, which is not efficient when we know the length of the string. Instead, we can write directly into the string using string.Create, which can be implemented in the convertible type's ToString method.

I've added `EnsureInitialised` before calling the base type. This would/should have been done in TryFormat anyway so shouldn't be breaking.

For `Identifier` it's roughly half (because we're doing one write instead of two)

| Method                |     Mean |    Error |   StdDev | Ratio | Allocated | Alloc Ratio |
| --------------------- | -------: | -------: | -------: | ----: | --------: | ----------: |
| ToString_Default_Main | 29.12 ns | 0.051 ns | 0.046 ns |  1.00 |     104 B |        1.00 |
| ToString_Default_PR   | 14.09 ns | 0.029 ns | 0.027 ns |  0.48 |     104 B |        1.00 |

This does mean, however, that **types can now format in any way that the convertible value supports**. For `Identifier`, formatting as lower/upper completely changes the meaning, so supporting it may not be desired. If we don't want to support all of the base formats, we will need to override it ourselves and throw format exceptions. I've added support for this in the source generator.

We could probably do something smarter for types using interned strings too, but that can be another PR.
