### PR TITLE
Remove obsolete from Tag.{Starts/Ends}With(ROS<char>)

### DIFF
--- a/src/DSE.Open.Values/Tag.cs
+++ b/src/DSE.Open.Values/Tag.cs
@@ -129,7 +129,6 @@ public readonly partial struct Tag : IComparableValue<Tag, AsciiString>, IUtf8Sp
         return _value.StartsWith(value);
     }
 
-    [Obsolete("Use StartsWith(ReadOnlySpan<AsciiChar>) instead.")]
     public bool StartsWith(ReadOnlySpan<char> value)
     {
         return _value.StartsWith(value);
@@ -150,7 +149,6 @@ public readonly partial struct Tag : IComparableValue<Tag, AsciiString>, IUtf8Sp
         return _value.EndsWith(value);
     }
 
-    [Obsolete("Use EndsWith(ReadOnlySpan<AsciiChar>) instead.")]
     public bool EndsWith(ReadOnlySpan<char> value)
     {
         return _value.EndsWith(value);


### PR DESCRIPTION
This was obsoleted because the conversion from chars to bytes was more expensive, so comparing against ROS<byte> was prefereable. With the Ascii class in NET8 it's now much more efficient, so we can remove the attributes.