### PR TITLE
Ensure StreamReader is disposed after reading string in StreamExtensions

### DIFF
--- a/src/DSE.Open/IO/StreamExtensions.cs
+++ b/src/DSE.Open/IO/StreamExtensions.cs
@@ -101,13 +101,12 @@ public static class StreamExtensions
 
     public static Task<string> ReadToEndAsStringAsync(this Stream stream)
     {
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEndAsync();
+        return ReadToEndAsStringAsync(stream, Encoding.UTF8);
     }
 
-    public static Task<string> ReadToEndAsStringAsync(this Stream stream, Encoding encoding)
+    public static async Task<string> ReadToEndAsStringAsync(this Stream stream, Encoding encoding)
     {
         using var reader = new StreamReader(stream, encoding);
-        return reader.ReadToEndAsync();
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
     }
 }

--- a/test/DSE.Open.Tests/IO/StreamExtensionsTests.cs
+++ b/test/DSE.Open.Tests/IO/StreamExtensionsTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text;
+using DSE.Open.IO;
+
+namespace DSE.Open.Tests.IO;
+
+public class StreamExtensionsTests
+{
+    [Fact]
+    public async Task ReadToEndAsStringAsync_ReadsCorrectly()
+    {
+        var stream = new MemoryStream(1024);
+        var bytes = "Hello, World!"u8.ToArray();
+        await stream.WriteAsync(bytes);
+        stream.Position = 0;
+
+        var result = await stream.ReadToEndAsStringAsync();
+
+        Assert.Equal("Hello, World!", result);
+        Assert.Throws<ObjectDisposedException>(() => stream.Write("Hi!"u8.ToArray()));
+    }
+}


### PR DESCRIPTION
I'm not sure its actually possible to dispose before completing here, but better safe than sorry.
