### PR TITLE
Add formatting options and extend tests for AsciiChar

### DIFF
--- a/src/DSE.Open/AsciiChar2.cs
+++ b/src/DSE.Open/AsciiChar2.cs
@@ -304,7 +304,7 @@ public readonly struct AsciiChar2
     {
         if (s.Length == CharCount && AsciiChar.IsAscii(s[0]) && AsciiChar.IsAscii(s[1]))
         {
-            result = new AsciiChar2(s);
+            result = new AsciiChar2(s[..2]);
             return true;
         }
 

--- a/src/DSE.Open/AsciiChar2.cs
+++ b/src/DSE.Open/AsciiChar2.cs
@@ -272,7 +272,8 @@ public readonly struct AsciiChar2
         return string.Create(CharCount, (this, format, formatProvider), (span, state) =>
         {
             var (value, format, formatProvider) = state;
-            Debug.Assert(value.TryFormat(span, out _, format, formatProvider));
+            var result = value.TryFormat(span, out _, format, formatProvider);
+            Debug.Assert(result);
         });
     }
 

--- a/src/DSE.Open/AsciiChar2.cs
+++ b/src/DSE.Open/AsciiChar2.cs
@@ -2,6 +2,7 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -109,63 +110,130 @@ public readonly struct AsciiChar2
         return c != 0 ? c : _c1.CompareTo(other._c1);
     }
 
-    public bool Equals(AsciiChar2 other) => _c0 == other._c0 && _c1 == other._c1;
-
     public bool EqualsCaseInsensitive(AsciiChar2 other)
-        => AsciiChar.EqualsCaseInsensitive(_c0, other._c0) && AsciiChar.EqualsCaseInsensitive(_c1, other._c1);
+    {
+        return AsciiChar.EqualsCaseInsensitive(_c0, other._c0) && AsciiChar.EqualsCaseInsensitive(_c1, other._c1);
+    }
 
     public int CompareToCaseInsensitive(AsciiChar2 other)
     {
         var c = AsciiChar.CompareToCaseInsensitive(_c0, other._c0);
 
-        return c != 0 ? c : AsciiChar.CompareToCaseInsensitive(_c1, other._c1);
+        return (c != 0) switch
+        {
+            true => c,
+            _ => AsciiChar.CompareToCaseInsensitive(_c1, other._c1)
+        };
     }
 
-    public bool Equals(string other) => Equals(other.AsSpan());
+    public bool Equals(AsciiChar2 other)
+    {
+        return _c0 == other._c0 && _c1 == other._c1;
+    }
 
-    public bool Equals(ReadOnlyMemory<char> other) => Equals(other.Span);
+    public bool Equals(string other)
+    {
+        return Equals(other.AsSpan());
+    }
 
-    public bool Equals(ReadOnlySpan<char> other) => other.Length == CharCount && other[0] == _c0 && other[1] == _c1;
+    public bool Equals(ReadOnlyMemory<char> other)
+    {
+        return Equals(other.Span);
+    }
 
-    public override bool Equals(object? obj) => obj is AsciiChar2 other && Equals(other);
+    public bool Equals(ReadOnlySpan<char> other)
+    {
+        return other.Length == CharCount && other[0] == _c0 && other[1] == _c1;
+    }
 
-    public override int GetHashCode() => HashCode.Combine(_c0, _c1);
+    public override bool Equals(object? obj)
+    {
+        return obj is AsciiChar2 other && Equals(other);
+    }
 
-    public override string ToString() => ToString(null, null);
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(_c0, _c1);
+    }
 
-    public Char2 ToChar2() => new((char)_c0, (char)_c1);
+    public Char2 ToChar2()
+    {
+        return new Char2(_c0, _c1);
+    }
 
-    public char[] ToCharArray() => [(char)_c0, _c1];
+    public char[] ToCharArray()
+    {
+        return [_c0, _c1];
+    }
 
-    public static AsciiChar2 FromString(string value) => new(value.AsSpan());
+    public static AsciiChar2 FromString(string value)
+    {
+        return new AsciiChar2(value.AsSpan());
+    }
 
-    public static AsciiChar2 FromSpan(ReadOnlySpan<AsciiChar> span) => new(span);
+    public static AsciiChar2 FromSpan(ReadOnlySpan<AsciiChar> span)
+    {
+        return new AsciiChar2(span);
+    }
 
-    public static AsciiChar2 FromByteSpan(ReadOnlySpan<byte> span) => new(span);
+    public static AsciiChar2 FromByteSpan(ReadOnlySpan<byte> span)
+    {
+        return new AsciiChar2(span);
+    }
 
-    public static AsciiChar2 FromCharSpan(ReadOnlySpan<char> span) => new(span);
+    public static AsciiChar2 FromCharSpan(ReadOnlySpan<char> span)
+    {
+        return new AsciiChar2(span);
+    }
 
-    public static bool operator ==(AsciiChar2 left, AsciiChar2 right) => left.Equals(right);
+    public static bool operator ==(AsciiChar2 left, AsciiChar2 right)
+    {
+        return left.Equals(right);
+    }
 
-    public static bool operator !=(AsciiChar2 left, AsciiChar2 right) => !left.Equals(right);
+    public static bool operator !=(AsciiChar2 left, AsciiChar2 right)
+    {
+        return !left.Equals(right);
+    }
 
-    public static implicit operator string(AsciiChar2 value) => value.ToString();
+    public static implicit operator string(AsciiChar2 value)
+    {
+        return value.ToString();
+    }
 
-    public static implicit operator Char2(AsciiChar2 value) => value.ToChar2();
+    public static implicit operator Char2(AsciiChar2 value)
+    {
+        return value.ToChar2();
+    }
 
-    public static explicit operator AsciiChar2(string value) => FromString(value);
+    public static explicit operator AsciiChar2(string value)
+    {
+        return FromString(value);
+    }
 
 #pragma warning disable CA2225 // Operator overloads have named alternates
 
-    public static explicit operator AsciiChar2(ReadOnlySpan<byte> value) => FromByteSpan(value);
+    public static explicit operator AsciiChar2(ReadOnlySpan<byte> value)
+    {
+        return FromByteSpan(value);
+    }
 
-    public static explicit operator AsciiChar2(ReadOnlySpan<char> value) => FromCharSpan(value);
+    public static explicit operator AsciiChar2(ReadOnlySpan<char> value)
+    {
+        return FromCharSpan(value);
+    }
 
 #pragma warning restore CA2225 // Operator overloads have named alternates
 
-    public AsciiChar2 ToUpper() => new(_c0.ToUpper(), _c1.ToUpper());
+    public AsciiChar2 ToUpper()
+    {
+        return new AsciiChar2(_c0.ToUpper(), _c1.ToUpper());
+    }
 
-    public AsciiChar2 ToLower() => new(_c0.ToLower(), _c1.ToLower());
+    public AsciiChar2 ToLower()
+    {
+        return new AsciiChar2(_c0.ToLower(), _c1.ToLower());
+    }
 
     public bool TryFormat(
         Span<char> destination,
@@ -173,11 +241,11 @@ public readonly struct AsciiChar2
         ReadOnlySpan<char> format,
         IFormatProvider? provider)
     {
-        if (destination.Length >= CharCount)
+        if (destination.Length >= 2)
         {
-            destination[0] = (char)_c0;
-            destination[1] = (char)_c1;
-            charsWritten = CharCount;
+            _c0.TryFormat(destination, out _, format, provider);
+            _c1.TryFormat(destination[1..], out _, format, provider);
+            charsWritten = 2;
             return true;
         }
 
@@ -185,26 +253,38 @@ public readonly struct AsciiChar2
         return false;
     }
 
+    public override string ToString()
+    {
+        return ToString(null, null);
+    }
+
+    /// <summary>
+    /// Returns a string representation of the value using the specified format and culture-specific format information.
+    /// <remarks>
+    /// The <paramref name="format"/> can be unspecified or either 'L' or 'U' to convert the value to lower or upper case respectively.
+    /// </remarks>
+    /// </summary>
+    /// <param name="format"></param>
+    /// <param name="formatProvider"></param>
+    /// <returns></returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
-        => string.Create(CharCount, this, (span, char2) =>
+    {
+        return string.Create(CharCount, (this, format, formatProvider), (span, state) =>
         {
-            span[0] = char2._c0;
-            span[1] = char2._c1;
+            var (value, format, formatProvider) = state;
+            Debug.Assert(value.TryFormat(span, out _, format, formatProvider));
         });
+    }
 
     public string ToStringLower()
-        => string.Create(CharCount, this, (span, char2) =>
-        {
-            span[0] = char2._c0.ToLower();
-            span[1] = char2._c1.ToLower();
-        });
+    {
+        return ToString("L", null);
+    }
 
     public string ToStringUpper()
-        => string.Create(CharCount, this, (span, char2) =>
-        {
-            span[0] = char2._c0.ToUpper();
-            span[1] = char2._c1.ToUpper();
-        });
+    {
+        return ToString("U", null);
+    }
 
     public static AsciiChar2 Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
     {
@@ -220,10 +300,9 @@ public readonly struct AsciiChar2
     public static bool TryParse(
         ReadOnlySpan<char> s,
         IFormatProvider? provider,
-        [MaybeNullWhen(false)] out AsciiChar2 result)
+        out AsciiChar2 result)
     {
-        if (s.Length == CharCount && AsciiChar.IsAscii(s[0])
-            && AsciiChar.IsAscii(s[1]))
+        if (s.Length == CharCount && AsciiChar.IsAscii(s[0]) && AsciiChar.IsAscii(s[1]))
         {
             result = new AsciiChar2(s);
             return true;
@@ -242,13 +321,20 @@ public readonly struct AsciiChar2
     public static bool TryParse(
         [NotNullWhen(true)] string? s,
         IFormatProvider? provider,
-        [MaybeNullWhen(false)] out AsciiChar2 result)
-        => TryParse(s.AsSpan(), provider, out result);
+        out AsciiChar2 result)
+    {
+        return TryParse(s.AsSpan(), provider, out result);
+    }
 
-    static string IConvertibleTo<AsciiChar2, string>.ConvertTo(AsciiChar2 value) => value.ToString();
+    static string IConvertibleTo<AsciiChar2, string>.ConvertTo(AsciiChar2 value)
+    {
+        return value.ToString();
+    }
 
     static bool ITryConvertibleFrom<AsciiChar2, string>.TryFromValue(string value, out AsciiChar2 result)
-        => TryParse(value, null, out result);
+    {
+        return TryParse(value, null, out result);
+    }
 
     public static AsciiChar2 Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider)
     {
@@ -264,12 +350,11 @@ public readonly struct AsciiChar2
     public static bool TryParse(
         ReadOnlySpan<byte> utf8Text,
         IFormatProvider? provider,
-        [MaybeNullWhen(false)] out AsciiChar2 result
-    )
+        out AsciiChar2 result)
     {
-        if (utf8Text.Length == MaxSerializedByteLength)
+        if (utf8Text.Length == MaxSerializedByteLength && AsciiChar.IsAscii(utf8Text[0]) && AsciiChar.IsAscii(utf8Text[1]))
         {
-            result = new AsciiChar2((AsciiChar)utf8Text[0], (AsciiChar)utf8Text[1]);
+            result = new AsciiChar2(new AsciiChar(utf8Text[0]), new AsciiChar(utf8Text[1]));
             return true;
         }
 
@@ -281,13 +366,12 @@ public readonly struct AsciiChar2
         Span<byte> utf8Destination,
         out int bytesWritten,
         ReadOnlySpan<char> format,
-        IFormatProvider? provider
-    )
+        IFormatProvider? provider)
     {
         if (utf8Destination.Length >= MaxSerializedByteLength)
         {
-            utf8Destination[0] = (byte)_c0;
-            utf8Destination[1] = (byte)_c1;
+            _c0.TryFormat(utf8Destination, out _, format, provider);
+            _c1.TryFormat(utf8Destination[1..], out _, format, provider);
             bytesWritten = MaxSerializedByteLength;
             return true;
         }
@@ -296,11 +380,23 @@ public readonly struct AsciiChar2
         return false;
     }
 
-    public static bool operator <(AsciiChar2 left, AsciiChar2 right) => left.CompareTo(right) < 0;
+    public static bool operator <(AsciiChar2 left, AsciiChar2 right)
+    {
+        return left.CompareTo(right) < 0;
+    }
 
-    public static bool operator <=(AsciiChar2 left, AsciiChar2 right) => left.CompareTo(right) <= 0;
+    public static bool operator <=(AsciiChar2 left, AsciiChar2 right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
 
-    public static bool operator >(AsciiChar2 left, AsciiChar2 right) => left.CompareTo(right) > 0;
+    public static bool operator >(AsciiChar2 left, AsciiChar2 right)
+    {
+        return left.CompareTo(right) > 0;
+    }
 
-    public static bool operator >=(AsciiChar2 left, AsciiChar2 right) => left.CompareTo(right) >= 0;
+    public static bool operator >=(AsciiChar2 left, AsciiChar2 right)
+    {
+        return left.CompareTo(right) >= 0;
+    }
 }

--- a/src/DSE.Open/AsciiChar3.cs
+++ b/src/DSE.Open/AsciiChar3.cs
@@ -87,20 +87,37 @@ public readonly struct AsciiChar3
         c2 = _c2;
     }
 
-    public bool Equals(AsciiChar3 other) => _c0 == other._c0 && _c1 == other._c1 && _c2 == other._c2;
+    public bool Equals(AsciiChar3 other)
+    {
+        return _c0 == other._c0 && _c1 == other._c1 && _c2 == other._c2;
+    }
 
-    public bool Equals(string other) => Equals(other.AsSpan());
+    public bool Equals(string other)
+    {
+        return Equals(other.AsSpan());
+    }
 
-    public bool Equals(ReadOnlyMemory<char> other) => Equals(other.Span);
+    public bool Equals(ReadOnlyMemory<char> other)
+    {
+        return Equals(other.Span);
+    }
 
-    public bool Equals(ReadOnlySpan<char> other) => other.Length == CharCount && other[0] == _c0 && other[1] == _c1 && other[2] == _c2;
+    public bool Equals(ReadOnlySpan<char> other)
+    {
+        return other.Length == CharCount && other[0] == _c0 && other[1] == _c1 && other[2] == _c2;
+    }
 
-    public override bool Equals(object? obj) => obj is AsciiChar3 other && Equals(other);
+    public override bool Equals(object? obj)
+    {
+        return obj is AsciiChar3 other && Equals(other);
+    }
 
     public bool EqualsCaseInsensitive(AsciiChar3 other)
-        => AsciiChar.EqualsCaseInsensitive(_c0, other._c0)
-        && AsciiChar.EqualsCaseInsensitive(_c1, other._c1)
-        && AsciiChar.EqualsCaseInsensitive(_c2, other._c2);
+    {
+        return AsciiChar.EqualsCaseInsensitive(_c0, other._c0)
+               && AsciiChar.EqualsCaseInsensitive(_c1, other._c1)
+               && AsciiChar.EqualsCaseInsensitive(_c2, other._c2);
+    }
 
     public int CompareToCaseInsensitive(AsciiChar3 other)
     {
@@ -130,39 +147,78 @@ public readonly struct AsciiChar3
         return c != 0 ? c : _c2.CompareTo(other._c2);
     }
 
-    public override int GetHashCode() => HashCode.Combine(_c0, _c1, _c2);
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(_c0, _c1, _c2);
+    }
 
-    public override string ToString() => ToString(null, null);
+    public override string ToString()
+    {
+        return ToString(null, null);
+    }
 
-    public Char3 ToChar3() => new((char)_c0, (char)_c1, (char)_c2);
+    public Char3 ToChar3()
+    {
+        return new Char3((char)_c0, (char)_c1, (char)_c2);
+    }
 
-    public char[] ToCharArray() => [(char)_c0, _c1, _c2];
+    public char[] ToCharArray()
+    {
+        return [(char)_c0, _c1, _c2];
+    }
 
-    public static AsciiChar3 FromString(string value) => new(value.AsSpan());
+    public static AsciiChar3 FromString(string value)
+    {
+        return new AsciiChar3(value.AsSpan());
+    }
 
-    public static AsciiChar3 FromSpan(ReadOnlySpan<AsciiChar> span) => new(span);
+    public static AsciiChar3 FromSpan(ReadOnlySpan<AsciiChar> span)
+    {
+        return new AsciiChar3(span);
+    }
 
-    public static bool operator ==(AsciiChar3 left, AsciiChar3 right) => left.Equals(right);
+    public static bool operator ==(AsciiChar3 left, AsciiChar3 right)
+    {
+        return left.Equals(right);
+    }
 
-    public static bool operator !=(AsciiChar3 left, AsciiChar3 right) => !left.Equals(right);
+    public static bool operator !=(AsciiChar3 left, AsciiChar3 right)
+    {
+        return !left.Equals(right);
+    }
 
-    public static implicit operator string(AsciiChar3 value) => value.ToString();
+    public static implicit operator string(AsciiChar3 value)
+    {
+        return value.ToString();
+    }
 
-    public static implicit operator Char3(AsciiChar3 value) => value.ToChar3();
+    public static implicit operator Char3(AsciiChar3 value)
+    {
+        return value.ToChar3();
+    }
 
-    public static explicit operator AsciiChar3(string value) => FromString(value);
+    public static explicit operator AsciiChar3(string value)
+    {
+        return FromString(value);
+    }
 
-    public AsciiChar3 ToUpper() => new(_c0.ToUpper(), _c1.ToUpper(), _c2.ToUpper());
+    public AsciiChar3 ToUpper()
+    {
+        return new AsciiChar3(_c0.ToUpper(), _c1.ToUpper(), _c2.ToUpper());
+    }
 
-    public AsciiChar3 ToLower() => new(_c0.ToLower(), _c1.ToLower(), _c2.ToLower());
+    public AsciiChar3 ToLower()
+    {
+        return new AsciiChar3(_c0.ToLower(), _c1.ToLower(), _c2.ToLower());
+    }
 
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
         if (destination.Length >= CharCount)
         {
-            destination[0] = _c0;
-            destination[1] = _c1;
-            destination[2] = _c2;
+            _c0.TryFormat(destination, out _, format, provider);
+            _c1.TryFormat(destination[1..], out _, format, provider);
+            _c2.TryFormat(destination[2..], out _, format, provider);
             charsWritten = CharCount;
             return true;
         }
@@ -172,28 +228,23 @@ public readonly struct AsciiChar3
     }
 
     public string ToString(string? format, IFormatProvider? formatProvider)
-        => string.Create(CharCount, this, (span, value) =>
+    {
+        return string.Create(CharCount, (this, format, formatProvider), (span, state) =>
         {
-            span[0] = value._c0;
-            span[1] = value._c1;
-            span[2] = value._c2;
+            var (value, format, formatProvider) = state;
+            value.TryFormat(span, out _, format, formatProvider);
         });
+    }
 
     public string ToStringLower()
-        => string.Create(CharCount, this, (span, value) =>
-        {
-            span[0] = value._c0.ToLower();
-            span[1] = value._c1.ToLower();
-            span[2] = value._c2.ToLower();
-        });
+    {
+        return ToString("L", null);
+    }
 
     public string ToStringUpper()
-        => string.Create(CharCount, this, (span, value) =>
-        {
-            span[0] = value._c0.ToUpper();
-            span[1] = value._c1.ToUpper();
-            span[2] = value._c2.ToUpper();
-        });
+    {
+        return ToString("U", null);
+    }
 
     public static AsciiChar3 Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
     {
@@ -209,10 +260,10 @@ public readonly struct AsciiChar3
     public static bool TryParse(
         ReadOnlySpan<char> s,
         IFormatProvider? provider,
-        [MaybeNullWhen(false)] out AsciiChar3 result)
+        out AsciiChar3 result)
     {
         if (s.Length == CharCount && AsciiChar.IsAscii(s[0])
-            && AsciiChar.IsAscii(s[1]) && AsciiChar.IsAscii(s[2]))
+                                  && AsciiChar.IsAscii(s[1]) && AsciiChar.IsAscii(s[2]))
         {
             result = new AsciiChar3(s);
             return true;
@@ -228,13 +279,20 @@ public readonly struct AsciiChar3
         return Parse(s.AsSpan(), provider);
     }
 
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out AsciiChar3 result)
-        => TryParse(s.AsSpan(), provider, out result);
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out AsciiChar3 result)
+    {
+        return TryParse(s.AsSpan(), provider, out result);
+    }
 
-    static string IConvertibleTo<AsciiChar3, string>.ConvertTo(AsciiChar3 value) => value.ToString();
+    static string IConvertibleTo<AsciiChar3, string>.ConvertTo(AsciiChar3 value)
+    {
+        return value.ToString();
+    }
 
     static bool ITryConvertibleFrom<AsciiChar3, string>.TryFromValue(string value, out AsciiChar3 result)
-        => TryParse(value, null, out result);
+    {
+        return TryParse(value, null, out result);
+    }
 
     public static AsciiChar3 Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider)
     {
@@ -250,7 +308,7 @@ public readonly struct AsciiChar3
     public static bool TryParse(
         ReadOnlySpan<byte> utf8Text,
         IFormatProvider? provider,
-        [MaybeNullWhen(false)] out AsciiChar3 result)
+        out AsciiChar3 result)
     {
         if (utf8Text.Length != CharCount
             || !AsciiChar.IsAscii(utf8Text[0])
@@ -271,24 +329,37 @@ public readonly struct AsciiChar3
         ReadOnlySpan<char> format,
         IFormatProvider? provider)
     {
-        if (utf8Destination.Length < MaxSerializedByteLength)
+        if (utf8Destination.Length >= CharCount)
         {
-            bytesWritten = 0;
-            return false;
+            _c0.TryFormat(utf8Destination, out _, format, provider);
+            _c1.TryFormat(utf8Destination[1..], out _, format, provider);
+            _c2.TryFormat(utf8Destination[2..], out _, format, provider);
+
+            bytesWritten = CharCount;
+            return true;
         }
 
-        utf8Destination[0] = (byte)_c0;
-        utf8Destination[1] = (byte)_c1;
-        utf8Destination[2] = (byte)_c2;
-        bytesWritten = MaxSerializedByteLength;
-        return true;
+        bytesWritten = 0;
+        return false;
     }
 
-    public static bool operator <(AsciiChar3 left, AsciiChar3 right) => left.CompareTo(right) < 0;
+    public static bool operator <(AsciiChar3 left, AsciiChar3 right)
+    {
+        return left.CompareTo(right) < 0;
+    }
 
-    public static bool operator <=(AsciiChar3 left, AsciiChar3 right) => left.CompareTo(right) <= 0;
+    public static bool operator <=(AsciiChar3 left, AsciiChar3 right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
 
-    public static bool operator >(AsciiChar3 left, AsciiChar3 right) => left.CompareTo(right) > 0;
+    public static bool operator >(AsciiChar3 left, AsciiChar3 right)
+    {
+        return left.CompareTo(right) > 0;
+    }
 
-    public static bool operator >=(AsciiChar3 left, AsciiChar3 right) => left.CompareTo(right) >= 0;
+    public static bool operator >=(AsciiChar3 left, AsciiChar3 right)
+    {
+        return left.CompareTo(right) >= 0;
+    }
 }

--- a/test/DSE.Open.Tests/AsciiChar2Tests.cs
+++ b/test/DSE.Open.Tests/AsciiChar2Tests.cs
@@ -33,4 +33,15 @@ public class AsciiChar2Tests
         Assert.False(result);
         Assert.Equal(default, value);
     }
+
+    [Fact]
+    public void TryParse_WithTooManyValidChars_ShouldReturnFalse()
+    {
+        // Act
+        var result = AsciiChar2.TryParse("abc"u8, default, out var value);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, value);
+    }
 }

--- a/test/DSE.Open.Tests/AsciiChar2Tests.cs
+++ b/test/DSE.Open.Tests/AsciiChar2Tests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Tests;
+
+public class AsciiChar2Tests
+{
+    [Fact]
+    public void TryParse_WithInvalidLength_ShouldReturnFalse()
+    {
+        // Arrange
+        var input = "abc"u8.ToArray();
+
+        // Act
+        var result = AsciiChar2.TryParse(input, default, out var value);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
+    public void TryParse_WithInvalidChars_ShouldReturnFalse()
+    {
+        // Arrange
+        const char ch = (char)129;
+        Span<char> input = [ch, ch];
+
+        // Act
+        var result = AsciiChar2.TryParse(input, default, out var value);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, value);
+    }
+}

--- a/test/DSE.Open.Tests/AsciiCharTests.cs
+++ b/test/DSE.Open.Tests/AsciiCharTests.cs
@@ -63,6 +63,75 @@ public class AsciiCharTests
     }
 
     [Fact]
+    public void TryFormatUtf8_WithCorrectBuffer_ShouldReturnTrue()
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        Span<byte> buffer = stackalloc byte[1];
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, default, default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, charsWritten);
+    }
+
+    [Fact]
+    public void TryFormatUtf8_WithInvalidBuffer_ShouldReturnFalse()
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        Span<byte> buffer = stackalloc byte[0];
+
+        // Act
+        var result = value.TryFormat(buffer, out var charsWritten, default, default);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(0, charsWritten);
+    }
+
+    [Theory]
+    [InlineData('a', "u", 'A')]
+    [InlineData('A', "u", 'A')]
+    [InlineData('a', "l", 'a')]
+    [InlineData('A', "l", 'a')]
+    [InlineData('a', "", 'a')]
+    [InlineData('A', "", 'A')]
+    public void TryFormatUtf8_CorrectBuffers(char value, string format, char expected)
+    {
+        // Arrange
+        var asciiChar = (AsciiChar)value;
+        Span<byte> buffer = stackalloc byte[1];
+
+        // Act
+        var result = asciiChar.TryFormat(buffer, out var charsWritten, format, default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, charsWritten);
+        Assert.Equal((byte)expected, buffer[0]);
+    }
+
+    [Theory]
+    [InlineData("x")]
+    [InlineData("AB")]
+    public void TryFormatUtf8_WithInvalidFormat_ShouldThrowFormatException(string format)
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        var buffer = new byte[1];
+
+        // Act
+        void Act() => value.TryFormat(buffer, out _, format, default);
+
+        // Assert
+        _ = Assert.Throws<FormatException>(Act);
+    }
+
+
+    [Fact]
     public void TryFormat_WithCorrectBuffer_ShouldReturnTrue()
     {
         // Arrange
@@ -90,5 +159,66 @@ public class AsciiCharTests
         // Assert
         Assert.False(result);
         Assert.Equal(0, charsWritten);
+    }
+
+    [Theory]
+    [InlineData('a', "u", 'A')]
+    [InlineData('A', "u", 'A')]
+    [InlineData('a', "l", 'a')]
+    [InlineData('A', "l", 'a')]
+    [InlineData('a', "", 'a')]
+    [InlineData('A', "", 'A')]
+    public void TryFormat_CorrectBuffers(char value, string format, char expected)
+    {
+        // Arrange
+        var asciiChar = (AsciiChar)value;
+        Span<char> buffer = stackalloc char[1];
+
+        // Act
+        var result = asciiChar.TryFormat(buffer, out var charsWritten, format, default);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(1, charsWritten);
+        Assert.Equal(expected, buffer[0]);
+    }
+
+    [Theory]
+    [InlineData("x")]
+    [InlineData("AB")]
+    public void TryFormat_WithInvalidFormat_ShouldThrowFormatException(string format)
+    {
+        // Arrange
+        var value = (AsciiChar)'a';
+        var buffer = new char[1];
+
+        // Act
+        void Act() => value.TryFormat(buffer, out _, format, default);
+
+        // Assert
+        _ = Assert.Throws<FormatException>(Act);
+    }
+
+    [Theory]
+    [InlineData('a', "u", "A")]
+    [InlineData('a', "U", "A")]
+    [InlineData('A', "u", "A")]
+    [InlineData('a', "l", "a")]
+    [InlineData('A', "l", "a")]
+    [InlineData('A', "U", "A")]
+    [InlineData('a', "L", "a")]
+    [InlineData('A', "L", "a")]
+    [InlineData('a', "", "a")]
+    [InlineData('A', "", "A")]
+    public void ToString_WithFormat(char value, string format, string expected)
+    {
+        // Arrange
+        var asciiChar = (AsciiChar)value;
+
+        // Act
+        var result = asciiChar.ToString(format, default);
+
+        // Assert
+        Assert.Equal(expected, result);
     }
 }


### PR DESCRIPTION
`"l"`/`"L"` for lowercase, `"u"`/`"U"` for uppercase, empty for no change, otherwise `FormatException`

Changes 2 and 3 to use the same formatting and cleans up `ToString` methods.