### PR TITLE
Change generated IParsable.TryParse to call into ISpanParsable.TryParse

### DIFF
--- a/gen/DSE.Open.Values.Generators/ValueTypesGenerator.Emitter.cs
+++ b/gen/DSE.Open.Values.Generators/ValueTypesGenerator.Emitter.cs
@@ -462,12 +462,20 @@ public partial class ValueTypesGenerator
 
             if (spec.EmitTryParseStringMethod)
             {
-                writer.WriteBlock($"""
+                writer.WriteBlock($$"""
                                     public static bool TryParse(
                                         string? s,
                                         IFormatProvider? provider,
-                                        out {spec.ValueTypeName} result)
-                                        => {Namespaces.DseOpenValues}.ValueParser.TryParse<{spec.ValueTypeName}, {spec.ContainedValueTypeName}>(s, provider, out result);
+                                        out {{spec.ValueTypeName}} result)
+                                    {
+                                        if (s is null)
+                                        {
+                                            result = default;
+                                            return false;
+                                        }
+
+                                        return TryParse(s.AsSpan(), provider, out result);
+                                    }
                                     """);
 
                 writer.WriteBlock($"""


### PR DESCRIPTION
Prior to this change, the `IParsable.TryParse` method for values would call directly into the counterpart in the backing type. However, because values are required to implement ISpanParsable, there is always an available span version to call into.

If `ISpanParsable.TryParse` was overriden, but `IParsable.TryParse` was not, this would lead to divergent implementations. To avoid the need to override _both_ `TryParse` methods, this changes the source generator to assume the common case, that `null` is invalid, and to otherwise call into `ISpanParsable.TryParse`.