### PR TITLE
Allow Pagination.None when result contains error notifications

### DIFF
--- a/src/DSE.Open.Results/PaginatedCollectionValueAsyncResultBuilder.cs
+++ b/src/DSE.Open.Results/PaginatedCollectionValueAsyncResultBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
+using DSE.Open.Notifications;
+
 namespace DSE.Open.Results;
 
 public abstract class PaginatedCollectionValueAsyncResultBuilder<TResult, TValue> : CollectionValueAsyncResultBuilder<TResult, TValue>
@@ -15,13 +17,17 @@ public class PaginatedCollectionValueAsyncResultBuilder<TValue> : PaginatedColle
 {
     public override PaginatedCollectionValueAsyncResult<TValue> GetResult()
     {
-        return Pagination == Pagination.None
-            ? throw new InvalidOperationException("Pagination must be specified.")
-            : new PaginatedCollectionValueAsyncResult<TValue>
-            {
-                Value = Value ?? AsyncEnumerable.Empty<TValue>(),
-                Notifications = [.. Notifications],
-                Pagination = Pagination,
-            };
+        // Pagination can be `None` if there are errors (e.g., if the provided command was invalid).
+        if (Pagination == Pagination.None && !Notifications.AnyErrors())
+        {
+            throw new InvalidOperationException("Pagination must be specified.");
+        }
+
+        return new PaginatedCollectionValueAsyncResult<TValue>
+        {
+            Value = Value ?? AsyncEnumerable.Empty<TValue>(),
+            Notifications = [.. Notifications],
+            Pagination = Pagination,
+        };
     }
 }

--- a/src/DSE.Open.Results/PaginatedCollectionValueResultBuilder.cs
+++ b/src/DSE.Open.Results/PaginatedCollectionValueResultBuilder.cs
@@ -2,6 +2,7 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using DSE.Open.Collections.Generic;
+using DSE.Open.Notifications;
 
 namespace DSE.Open.Results;
 
@@ -20,6 +21,18 @@ public class PaginatedCollectionValueResultBuilder<TValue> : CollectionValueResu
 
     public override PaginatedCollectionValueResult<TValue> GetResult()
     {
+        ValidatePagination();
+        return Done();
+    }
+
+    private void ValidatePagination()
+    {
+        if (Notifications.AnyErrors())
+        {
+            // Pagination can be `None` if there are errors (e.g., if the provided command was invalid).
+            return;
+        }
+
         if (Pagination == Pagination.None)
         {
             throw new InvalidOperationException("Pagination must be specified.");
@@ -34,7 +47,10 @@ public class PaginatedCollectionValueResultBuilder<TValue> : CollectionValueResu
         {
             throw new InvalidOperationException("PageSize must be equal to or greater than the count of items.");
         }
+    }
 
+    private PaginatedCollectionValueResult<TValue> Done()
+    {
         return new PaginatedCollectionValueResult<TValue>
         {
             Value = [.. Items],


### PR DESCRIPTION
Otherwise, when command validation flags an issue, the pagination validation throws instead of allowing the notification to flow back to the caller.