### PR TITLE
Avoid indirection for value hashes

### DIFF
--- a/benchmarks/DSE.Open.Benchmarks/Values/IdentifierHashcodeBenchmark.cs
+++ b/benchmarks/DSE.Open.Benchmarks/Values/IdentifierHashcodeBenchmark.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using DSE.Open.Values;
+
+namespace DSE.Open.Benchmarks.Values;
+
+[MemoryDiagnoser]
+public class IdentifierHashcodeBenchmark
+{
+    private Identifier _identifier;
+    private AsciiString _identifierStr;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _identifier = Identifier.New();
+        _identifierStr = (AsciiString)_identifier;
+    }
+
+    [Benchmark(Baseline = true)]
+    public int BaseAsciiStringHash()
+    {
+        return _identifierStr.GetHashCode();
+    }
+
+    [Benchmark]
+    public int IdentifierHash()
+    {
+        return _identifier.GetHashCode();
+    }
+}

--- a/gen/DSE.Open.Values.Generators/ValueTypesGenerator.Emitter.cs
+++ b/gen/DSE.Open.Values.Generators/ValueTypesGenerator.Emitter.cs
@@ -226,7 +226,7 @@ public partial class ValueTypesGenerator
                 }
 
                 writer.WriteBlock("""
-                                      return HashCode.Combine(_value);
+                                      return _value.GetHashCode();
                                   }
                                   """);
             }


### PR DESCRIPTION
We are increasingly computing hashes of simple value types in dictionaries and sets.

Our source generator for values passes the hash code from the underlying type to HasCode.Combine. This is unnecessary.

Before:

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22635.2921)
13th Gen Intel Core i9-13900K, 1 CPU, 32 logical and 24 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2


| Method              | Mean     | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|-------------------- |---------:|----------:|----------:|------:|----------:|------------:|
| BaseAsciiStringHash | 6.492 ns | 0.0231 ns | 0.0205 ns |  1.00 |         - |          NA |
| IdentifierHash      | 8.602 ns | 0.0353 ns | 0.0313 ns |  1.33 |         - |          NA |
```

After:

```
| Method              | Mean     | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|-------------------- |---------:|----------:|----------:|------:|----------:|------------:|
| BaseAsciiStringHash | 6.559 ns | 0.0172 ns | 0.0153 ns |  1.00 |         - |          NA |
| IdentifierHash      | 6.590 ns | 0.0295 ns | 0.0276 ns |  1.01 |         - |          NA |
```

Benchmark:

```c#
public class IdentifierHashcodeBenchmark
{
    private Identifier _identifier;
    private AsciiString _identifierStr;

    [GlobalSetup]
    public void Setup()
    {
        _identifier = Identifier.New();
        _identifierStr = (AsciiString)_identifier;
    }

    [Benchmark(Baseline = true)]
    public int BaseAsciiStringHash()
    {
        return _identifierStr.GetHashCode();
    }

    [Benchmark]
    public int IdentifierHash()
    {
        return _identifier.GetHashCode();
    }
}
```