### PR TITLE
Start implementing remaining functionality for LikePattern

### DIFF
--- a/src/DSE.Open.Values/Text/LikePattern.cs
+++ b/src/DSE.Open.Values/Text/LikePattern.cs
@@ -17,17 +17,18 @@ namespace DSE.Open.Values.Text;
 /// <remarks>
 /// <list type="bullet">
 /// <item>
-/// <term>*</term>
+/// <term>?</term>
 /// <description>Matches any single character.</description>
 /// </item>
 /// <item>
-/// <term>?</term>
+/// <term>*</term>
 /// <description>Matches any string of zero or more characters.</description>
 /// </item>
 /// <item>
 /// <term>[ ]</term>
 /// <description>Any single character within the specified range
-/// <c>[a-f]</c> or set <c>[abcdef]</c>.</description>
+/// <c>[a-f]</c> or set <c>[abcdef]</c>. Brackets inside a set are treated as
+/// literals.</description>
 /// </item>
 /// <item>
 /// <term>[^ ]</term>

--- a/src/DSE.Open.Values/Text/LikePattern.cs
+++ b/src/DSE.Open.Values/Text/LikePattern.cs
@@ -466,6 +466,8 @@ public readonly record struct LikePattern : IEquatable<string>, ISpanParsable<Li
         ReadOnlySpan<char> range,
         out bool matched)
     {
+        Debug.Assert(range[1] == '-');
+
         var rangeStart = range[0];
         var rangeEnd = range[2];
 

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -2,9 +2,8 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using System.Text.Json;
-using DSE.Open.Values.Text;
 
-namespace DSE.Open.Values.Tests.Text;
+namespace DSE.Open.Values.Text;
 
 public class LikePatternTests
 {
@@ -30,6 +29,11 @@ public class LikePatternTests
     [InlineData(@"\[]", "[]")]
     [InlineData(@"\[\]", "[]")]
     [InlineData("a*?b", "abb")]
+    [InlineData("[az]", "z")]
+    [InlineData("[a-z]", "b")]
+    [InlineData("[^a-c]", "d")]
+    [InlineData("[a-c]", "b")]
+    [InlineData("[0-9]", "1")]
     public void IsMatch_returns_true_for_matches(string pattern, string value)
     {
         Assert.True(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));
@@ -52,6 +56,8 @@ public class LikePatternTests
     [InlineData("a*?b", "ab")] // `?` requires exactly 1 character, this pattern requires 2 'b's
     [InlineData("a*?", "a")] // `?` requires exactly 1 character, this pattern requires 1 more character
     [InlineData("a?", "a")]
+    [InlineData("[a-z]", "A")]
+    [InlineData("[0-9]", "a")]
     public void IsNotMatch_returns_false_for_nonmatches(string pattern, string value)
     {
         Assert.False(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -21,6 +21,9 @@ public class LikePatternTests
     [InlineData("a[abc][abc]", "aca")]
     [InlineData("a[[]", "a[")]
     [InlineData("[[]a*", "[abcde")]
+    [InlineData(@"a\[abc\]", "a[abc]")]
+    [InlineData(@"a\[\[\]\]", "a[[]]")]
+    [InlineData("a[[]]", "a[]")] // The outer brackets mean the inner are treated as literals
     public void IsMatch_returns_true_for_matches(string pattern, string value)
     {
         Assert.True(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));
@@ -39,6 +42,7 @@ public class LikePatternTests
     [InlineData("a[abc][abc]", "acd")]
     [InlineData("a[[]", "abc[")]
     [InlineData("[[]a*", "a[abcde")]
+    [InlineData(@"a\[abc\]", "aa")]
     public void IsNotMatch_returns_false_for_nonmatches(string pattern, string value)
     {
         Assert.False(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -27,6 +27,9 @@ public class LikePatternTests
     [InlineData(@"\\a", @"\a")]
     [InlineData(@"\*", "*")]
     [InlineData(@"\?", "?")]
+    [InlineData(@"\[]", "[]")]
+    [InlineData(@"\[\]", "[]")]
+    [InlineData("a*?b", "abb")]
     public void IsMatch_returns_true_for_matches(string pattern, string value)
     {
         Assert.True(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));
@@ -46,6 +49,9 @@ public class LikePatternTests
     [InlineData("a[[]", "abc[")]
     [InlineData("[[]a*", "a[abcde")]
     [InlineData(@"a\[abc\]", "aa")]
+    [InlineData("a*?b", "ab")] // `?` requires exactly 1 character, this pattern requires 2 'b's
+    [InlineData("a*?", "a")] // `?` requires exactly 1 character, this pattern requires 1 more character
+    [InlineData("a?", "a")]
     public void IsNotMatch_returns_false_for_nonmatches(string pattern, string value)
     {
         Assert.False(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -24,6 +24,9 @@ public class LikePatternTests
     [InlineData(@"a\[abc\]", "a[abc]")]
     [InlineData(@"a\[\[\]\]", "a[[]]")]
     [InlineData("a[[]]", "a[]")] // The outer brackets mean the inner are treated as literals
+    [InlineData(@"\\a", @"\a")]
+    [InlineData(@"\*", "*")]
+    [InlineData(@"\?", "?")]
     public void IsMatch_returns_true_for_matches(string pattern, string value)
     {
         Assert.True(new LikePattern(pattern).IsMatch(value, StringComparison.Ordinal));

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -61,9 +61,19 @@ public class LikePatternTests
     [InlineData("abcd*", "abcd%")]
     [InlineData("a[abc]", "a[abc]")]
     [InlineData("a[[][abc]", "a[[][abc]")]
+    [InlineData(@"a\[abc\]", "a[[]abc]")]
+    [InlineData(@"\*", "*")]
+    [InlineData(@"\?", "?")]
     public void ToSqlLikePattern_returns_expected_pattern(string pattern, string sqlLikePattern)
     {
-        Assert.Equal(new LikePattern(pattern).ToSqlLikePattern(), sqlLikePattern);
+        // Arrange
+        var likePattern = new LikePattern(pattern);
+
+        // Act
+        var result = likePattern.ToSqlLikePattern();
+
+        // Assert
+        Assert.Equal(sqlLikePattern, result);
     }
 
     [Fact]

--- a/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
+++ b/test/DSE.Open.Values.Tests/Text/LikePatternTests.cs
@@ -76,6 +76,8 @@ public class LikePatternTests
     [InlineData(@"a\[abc\]", "a[[]abc]")]
     [InlineData(@"\*", "*")]
     [InlineData(@"\?", "?")]
+    [InlineData("[a-z]", "[a-z]")]
+    [InlineData("[^a-z]", "[^a-z]")]
     public void ToSqlLikePattern_returns_expected_pattern(string pattern, string sqlLikePattern)
     {
         // Arrange


### PR DESCRIPTION
According to the comments:

1. `*` Matches any single character
2. `?` Matches any string of zero or more characters.
3. `[ ]` Matches any single character within the specified range (e.g., using range syntax `[a-f]` or specifying the set `[abcdef]`.
4. `[^...]` Any single character not within the specified set (specified like previous, e.g., `[^a-f]` or set `[^abcdef]`.

There's quite a lot of ambiguity here.

First, (1) and (2) presumably overlap: `*` $\subset$ `?`. 

Second, it is not clear when `?` terminates. Presumably a pattern `?` matches any possible value. `a?` matches any possible value where `value[0] == a` where `value.Length > 0`. The problems arise in cases where a pattern is like `a?c`. Does the `?` match the _whole_ value `abcabc`? I.e., is `?` greedy, or does it terminate on the first possible matching sequence (and therefore match only the first `abc`?

Third, how are brackets handled. Consider the case `a[[]]`. Does this match `a[[]]`, `a[]` or `a`? I _think_ regex would go with the second (and that is what I have implemented here so far).