### PR TITLE
Add a struct enumerator for ROVC

### DIFF
--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
@@ -125,14 +125,19 @@ public class ReadOnlyValueCollection<T>
         return hash.ToHashCode();
     }
 
-    public IEnumerator<T> GetEnumerator()
+    public Enumerator GetEnumerator()
     {
-        return _items.GetEnumerator();
+        return new Enumerator(this);
+    }
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return ((IEnumerable)_items).GetEnumerator();
+        return GetEnumerator();
     }
 
 #pragma warning disable CA2225 // Operator overloads have named alternates
@@ -156,6 +161,35 @@ public class ReadOnlyValueCollection<T>
     {
         return new ReadOnlyValueCollection<T>(collection);
     }
-
 #pragma warning restore CA2225 // Operator overloads have named alternates
+
+    public struct Enumerator : IEnumerator<T>
+    {
+        private List<T>.Enumerator _inner;
+
+        public Enumerator(ReadOnlyValueCollection<T> collection)
+        {
+            Guard.IsNotNull(collection);
+            _inner = collection._items.GetEnumerator();
+        }
+
+        public bool MoveNext()
+        {
+            return _inner.MoveNext();
+        }
+
+        public void Reset()
+        {
+            ((IEnumerator)_inner).Reset();
+        }
+
+        public T Current => _inner.Current;
+
+        object? IEnumerator.Current => _inner.Current;
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+    }
 }

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
@@ -178,7 +178,7 @@ public class ReadOnlyValueCollection<T>
             return _inner.MoveNext();
         }
 
-        public void Reset()
+        void IEnumerator.Reset()
         {
             ((IEnumerator)_inner).Reset();
         }

--- a/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
+++ b/src/DSE.Open/Collections/Generic/ReadOnlyValueCollection{T}.cs
@@ -180,7 +180,7 @@ public class ReadOnlyValueCollection<T>
 
         void IEnumerator.Reset()
         {
-            ((IEnumerator)_inner).Reset();
+            throw new NotSupportedException("Reset is not supported. Use a new enumerator instead.");
         }
 
         public T Current => _inner.Current;

--- a/test/DSE.Open.Tests/Collections/Generic/ReadOnlyValueCollectionTests.cs
+++ b/test/DSE.Open.Tests/Collections/Generic/ReadOnlyValueCollectionTests.cs
@@ -130,7 +130,7 @@ public class ReadOnlyValueCollectionTests
     }
 
     [Fact]
-    public void GetEnumerator_ShouldReturnStruct()
+    public void GetEnumerator_ShouldReturnStructEnumerator()
     {
         // Arrange
         ReadOnlyValueCollection<int> collection = [0, 1, 2];
@@ -139,7 +139,34 @@ public class ReadOnlyValueCollectionTests
         using var enumerator = collection.GetEnumerator();
 
         // Assert
-        Assert.IsType<ReadOnlyValueCollection<int>.Enumerator>(enumerator);
+        _ = Assert.IsType<ReadOnlyValueCollection<int>.Enumerator>(enumerator);
+    }
+
+    [Fact]
+    public void GetEnumerator_IEnumerable_ShouldReturnStructEnumerator()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [0, 1, 2];
+
+        // Act
+        var enumerator = ((IEnumerable)collection).GetEnumerator();
+
+        // Assert
+        _ = Assert.IsType<ReadOnlyValueCollection<int>.Enumerator>(enumerator);
+    }
+
+
+    [Fact]
+    public void GetEnumerator_IEnumerableT_ShouldReturnStructEnumerator()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [0, 1, 2];
+
+        // Act
+        using var enumerator = ((IEnumerable<int>)collection).GetEnumerator();
+
+        // Assert
+        _ = Assert.IsType<ReadOnlyValueCollection<int>.Enumerator>(enumerator);
     }
 
     [Fact]
@@ -153,6 +180,6 @@ public class ReadOnlyValueCollectionTests
         void Act() => ((IEnumerator)enumerator).Reset();
 
         // Assert
-        Assert.Throws<NotSupportedException>(Act);
+        _ = Assert.Throws<NotSupportedException>(Act);
     }
 }

--- a/test/DSE.Open.Tests/Collections/Generic/ReadOnlyValueCollectionTests.cs
+++ b/test/DSE.Open.Tests/Collections/Generic/ReadOnlyValueCollectionTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
+using System.Collections;
 using System.Text.Json;
 using DSE.Open.Collections.Generic;
 
@@ -89,5 +90,69 @@ public class ReadOnlyValueCollectionTests
         Assert.Equal(0, collection[0]);
         Assert.Equal(1, collection[1]);
         Assert.Equal(2, collection.Count);
+    }
+
+    [Fact]
+    public void Foreach_ShouldIterate()
+    {
+        // Arrange
+        const int lower = 0;
+        const int upper = 10;
+        ReadOnlyValueCollection<int> collection = [..Enumerable.Range(lower, upper)];
+
+        // Act
+        var acc = 0;
+
+        foreach (var item in collection)
+        {
+            acc += item;
+        }
+
+        // Assert
+        var expected = Enumerable.Range(lower, upper).Sum();
+        Assert.Equal(expected, acc);
+        Assert.Equal(expected, collection.Sum());
+    }
+
+    [Fact]
+    public void IEnumerable_Sum()
+    {
+        // Arrange
+        const int lower = 0;
+        const int upper = 10;
+        ReadOnlyValueCollection<int> collection = [..Enumerable.Range(lower, upper)];
+
+        // Act
+        var sum = collection.Sum();
+
+        // Assert
+        Assert.Equal(Enumerable.Range(lower, upper).Sum(), sum);
+    }
+
+    [Fact]
+    public void GetEnumerator_ShouldReturnStruct()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [0, 1, 2];
+
+        // Act
+        using var enumerator = collection.GetEnumerator();
+
+        // Assert
+        Assert.IsType<ReadOnlyValueCollection<int>.Enumerator>(enumerator);
+    }
+
+    [Fact]
+    public void Reset_ShouldThrowNotSupported()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [0, 1, 2];
+        using var enumerator = collection.GetEnumerator();
+
+        // Act
+        void Act() => ((IEnumerator)enumerator).Reset();
+
+        // Assert
+        Assert.Throws<NotSupportedException>(Act);
     }
 }


### PR DESCRIPTION
This avoids a box on direct enumeration. For iteration through interfaces this still boxes. Not sure if this is worth the extra code? I don't want to return the `List<T>.Enumerator` directly because that's leaking an implementation detail.