### PR TITLE
Add Update<T> representing updates to a value

### DIFF
--- a/src/DSE.Open.Requests/Update.cs
+++ b/src/DSE.Open.Requests/Update.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace DSE.Open.Requests;
+
+/// <summary>
+/// A helper class to create an <see cref="Update{T}"/> instance.
+/// </summary>
+public static class Update
+{
+    public static Update<T> New<T>(T value, UpdateMode mode)
+    {
+        if (mode is UpdateMode.None && value is not null)
+        {
+            throw new ArgumentException(
+                $"A {nameof(value)} must not be provided when the {nameof(mode)} is {nameof(UpdateMode.None)}",
+                nameof(value));
+        }
+
+        return new Update<T>(value, mode);
+    }
+
+    public static Update<T?> NewUpdate<T>(T value)
+    {
+        return new Update<T?>(value, UpdateMode.Update);
+    }
+
+    public static Update<T?> NoChange<T>()
+    {
+        return new Update<T?>(default, UpdateMode.None);
+    }
+}
+
+/// <summary>
+/// A discriminated union to represent an update request for a value, or no update request.
+/// </summary>
+/// <typeparam name="T">The type of the value</typeparam>
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+public readonly struct Update<T>
+#pragma warning restore CA1815
+{
+    private readonly T? _value;
+
+    internal Update(T? value, UpdateMode mode)
+    {
+        _value = value;
+        Mode = mode;
+    }
+
+    public UpdateMode Mode { get; }
+
+    /// <summary>
+    /// Gets the value
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="Mode"/> is <see cref="UpdateMode.None"/></exception>
+    public T GetValue()
+    {
+        if (!HasUpdate)
+        {
+            ThrowGetForNoUpdateException();
+        }
+
+        return _value;
+    }
+
+    /// <summary>
+    /// Gets the value if the <see cref="Mode"/> is not <see cref="UpdateMode.None"/>
+    /// </summary>
+    /// <param name="value">The value</param>
+    /// <returns><see langword="true"/> if the <see cref="Mode"/> is not <see cref="UpdateMode.None"/>; otherwise, <see langword="false"/></returns>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        if (HasUpdate)
+        {
+            value = _value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    [MemberNotNullWhen(true, nameof(_value))]
+    public bool HasUpdate => Mode is UpdateMode.Update;
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowGetForNoUpdateException()
+    {
+        throw new InvalidOperationException(
+            $"Cannot get value when {nameof(Update<T>)}.{nameof(Mode)} is {UpdateMode.None}");
+    }
+}
+
+public enum UpdateMode
+{
+    /// <summary>
+    /// Represents no update request. The value should not be changed.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Requests the update of a value.
+    /// </summary>
+    Update
+}

--- a/test/DSE.Open.Requests.Tests/UpdateTests.cs
+++ b/test/DSE.Open.Requests.Tests/UpdateTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Requests.Tests;
+
+public class UpdateTests
+{
+    [Fact]
+    public void NewUpdate_WithClass_ShouldCreate()
+    {
+        // Arrange
+        const string value = "value";
+
+        // Act
+        var update = Update.NewUpdate(value);
+
+        // Assert
+        Assert.Equal(UpdateMode.Update, update.Mode);
+        Assert.Equal(value, update.GetValue());
+    }
+
+    [Fact]
+    public void NewUpdate_WithStruct_ShouldCreate()
+    {
+        // Arrange
+        const int value = 42;
+
+        // Act
+        var update = Update.NewUpdate(value);
+
+        // Assert
+        Assert.Equal(UpdateMode.Update, update.Mode);
+        Assert.Equal(value, update.GetValue());
+    }
+
+    [Fact]
+    public void NewUpdate_WithNullStruct_ShouldCreate()
+    {
+        // Arrange
+        int? value = null;
+
+        // Act
+        var update = Update.NewUpdate(value);
+
+        // Assert
+        Assert.Equal(UpdateMode.Update, update.Mode);
+        Assert.Equal(value, update.GetValue());
+    }
+
+    [Fact]
+    public void New_WithNonDefaultValueAndModeNone_ShouldThrowArgumentException()
+    {
+        // Arrange
+        const int value = 42;
+
+        // Act
+        void Act() => _ = Update.New(value, UpdateMode.None);
+
+        // Assert
+        Assert.Throws<ArgumentException>(Act);
+    }
+
+    [Fact]
+    public void GetValue_WithNoChange_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var update = Update.NoChange<int>();
+
+        // Act
+        void Act() => update.GetValue();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(Act);
+    }
+
+    [Fact]
+    public void GetValue_WithChange_ShouldReturnValue()
+    {
+        // Arrange
+        const int innerValue = 42;
+        var update = Update.NewUpdate(innerValue);
+
+        // Act
+        var value = update.GetValue();
+
+        // Assert
+        Assert.Equal(innerValue, value);
+    }
+
+    [Fact]
+    public void TryGetValue_WithValue_ShouldReturnValueAndTrue()
+    {
+        // Arrange
+        const int innerValue = 42;
+        var update = Update.NewUpdate(innerValue);
+
+        // Act
+        var result = update.TryGetValue(out var value);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(innerValue, value);
+    }
+
+    [Fact]
+    public void TryGetValue_WithNoValue_ShouldReturnFalseAndDefault()
+    {
+        // Arrange
+        var update = Update.NoChange<int>();
+
+        // Act
+        var result = update.TryGetValue(out var value);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(default, value);
+    }
+}


### PR DESCRIPTION
In some APIs we were using `T?` to represent an update to a value. Yet, if that `T` is stored as `T?` in the DB, for example, we cannot distinguish between setting the value to `null` (clearing it) and requesting _no update_ to the value.

One example was

```cs
public Gender? Gender { get; init; }
```

forcing us to have `Gender.Unknown` to represent the 'cleared' state.

With this type we can instead have

```cs
public Update<Gender?> Gender { get; init; }
```

in the update request.

If we have an update, we can create it

```cs
request.Gender = Update.NewUpdate(Gender.Female);
```

or have no update as

```cs
request.Gender = Update.NoChange<Gender?>();
```

And then in a command handler, we would do something like

```cs
if (command.Gender.HasUpdate)
{
    user.Gender = command.Gender.GetValue();
}
```