### PR TITLE
Return inner value type when slicing paths

### DIFF
--- a/src/DSE.Open.Values/UriAsciiPath.cs
+++ b/src/DSE.Open.Values/UriAsciiPath.cs
@@ -51,9 +51,9 @@ public readonly partial struct UriAsciiPath
 
     public AsciiChar this[int index] => _value[index];
 
-    public UriAsciiPath Slice(int start, int length)
+    public AsciiString Slice(int start, int length)
     {
-        return new UriAsciiPath(_value.Slice(start, length));
+        return _value.Slice(start, length);
     }
 
     public ReadOnlySpan<AsciiChar> Span => _value.AsSpan();

--- a/src/DSE.Open.Values/UriPath.cs
+++ b/src/DSE.Open.Values/UriPath.cs
@@ -41,9 +41,9 @@ public readonly partial struct UriPath : IComparableValue<UriPath, CharSequence>
 
     public char this[int index] => _value[index];
 
-    public UriPath Slice(int start, int length)
+    public CharSequence Slice(int start, int length)
     {
-        return new UriPath(_value.Slice(start, length));
+        return _value.Slice(start, length);
     }
 
     public ReadOnlySpan<char> Span => _value.AsSpan();


### PR DESCRIPTION
Otherwise `path[..n]`, etc., can throw if the caller doesn't check that it is slicing inside a segment (such that the slice is a valid path) - which is unexpected for an indexer!

Callers can now do

```cs
var slice = path[..n];

if (!UriPath.TryParse(slice, out var segment)
{
    // Do some handling
}

// Use value
```