### PR TITLE
Add Single overloads for IReadOnlyList

### DIFF
--- a/src/DSE.Open/Collections/Generic/CollectionExtensions.Single.cs
+++ b/src/DSE.Open/Collections/Generic/CollectionExtensions.Single.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Collections.Generic;
+
+public static partial class CollectionExtensions
+{
+    public static TSource Single<TSource>(this IReadOnlyList<TSource> source)
+    {
+        var single = source.TryGetSingle(out var found);
+
+        if (!found)
+        {
+            ThrowHelper.ThrowNoElementsException();
+        }
+
+        return single!;
+    }
+
+    public static TSource? SingleOrDefault<TSource>(this IReadOnlyList<TSource> list)
+    {
+        var single = list.TryGetSingle(out var found);
+        return found ? single! : default;
+    }
+
+    private static TSource? TryGetSingle<TSource>(this IReadOnlyList<TSource> source, out bool found)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        switch (source.Count)
+        {
+            case 0:
+                found = false;
+                return default;
+            case 1:
+                found = true;
+                return source[0];
+        }
+
+        found = false;
+        ThrowHelper.ThrowMoreThanOneElementException();
+        return default;
+    }
+}
+
+static file class ThrowHelper
+{
+    public static void ThrowMoreThanOneElementException()
+    {
+        throw new InvalidOperationException("The collection contains more than one element.");
+    }
+
+    public static void ThrowNoElementsException()
+    {
+        throw new InvalidOperationException("The collection contains no elements.");
+    }
+}

--- a/test/DSE.Open.Tests/Collections/Generic/CollectionExtensionsTests.Single.cs
+++ b/test/DSE.Open.Tests/Collections/Generic/CollectionExtensionsTests.Single.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Collections.Generic;
+using CollectionExtensions = DSE.Open.Collections.Generic.CollectionExtensions;
+
+namespace DSE.Open.Tests.Collections.Generic;
+
+public sealed partial class CollectionExtensionsTests
+{
+    [Fact]
+    public void Single_WithSingle_ShouldReturnSingle()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [123];
+
+        // Act
+        var single = CollectionExtensions.Single(collection);
+
+        // Assert
+        Assert.Equal(((IEnumerable<int>)collection).Single(), single);
+    }
+
+    [Fact]
+    public void Single_WithZero_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> emptyCollection = [];
+
+        // Act
+        void Act() => _ = emptyCollection.Single();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(Act);
+    }
+
+    [Fact]
+    public void Single_WithMultiple_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> multipleCollection = [1, 2];
+
+        // Act
+        void Act() => _ = multipleCollection.Single();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(Act);
+    }
+
+    [Fact]
+    public void SingleOrDefault_WithSingle_ShouldReturnSingle()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> collection = [123];
+
+        // Act
+        var single = collection.SingleOrDefault();
+
+        // Assert
+        Assert.Equal(((IEnumerable<int>)collection).Single(), single);
+    }
+
+    [Fact]
+    public void SingleOrDefault_WithZero_ShouldReturnDefault()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> empty = [];
+
+        // Act
+        var result = empty.SingleOrDefault();
+
+        // Assert
+        Assert.Equal(((IEnumerable<int>)empty).SingleOrDefault(), result);
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void SingleOrDefault_WithMultiple_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        ReadOnlyValueCollection<int> multiple = [1, 2];
+
+        // Act
+        void Act() => _ = multiple.SingleOrDefault();
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(Act);
+    }
+}


### PR DESCRIPTION
<details>
<summary>SingleOrDefault benchmark results</summary>

```
BenchmarkDotNet v0.14.0, macOS Sonoma 14.6.1 (23G93) [Darwin 23.6.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.7 (8.0.724.31311), Arm64 RyuJIT AdvSIMD
```

| Method                               | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
| SingleOrDefault_Enumerable_Empty     | 11.105 ns | 0.0407 ns | 0.0380 ns |  0.81 |    0.00 |      40 B |        1.00 |
| SingleOrDefault_IReadOnlyList_Empty  |  1.109 ns | 0.0088 ns | 0.0073 ns |  0.08 |    0.00 |         - |        0.00 |
| SingleOrDefault_Enumerable_Single    | 13.719 ns | 0.0401 ns | 0.0355 ns |  1.00 |    0.00 |      40 B |        1.00 |
| SingleOrDefault_IReadOnlyList_Single |  1.776 ns | 0.0072 ns | 0.0064 ns |  0.13 |    0.00 |         - |        0.00 |

</details>