### PR TITLE
Avoid some variable length stackallocs

### DIFF
--- a/src/DSE.Open.Globalization/LanguageTag.cs
+++ b/src/DSE.Open.Globalization/LanguageTag.cs
@@ -96,13 +96,14 @@ public readonly partial struct LanguageTag
         }
 
         // Fall back to regex
-        Span<char> buffer = stackalloc char[value.Length];
+        Span<char> buffer = stackalloc char[MaxSerializedCharLength];
+
         for (var i = 0; i < value.Length; i++)
         {
             buffer[i] = (char)value[i];
         }
 
-        return s_regex.IsMatch(buffer);
+        return s_regex.IsMatch(buffer[..value.Length]);
     }
 
     /// <summary>

--- a/src/DSE.Open.Values/Identifier.cs
+++ b/src/DSE.Open.Values/Identifier.cs
@@ -166,14 +166,14 @@ public readonly partial struct Identifier : IEquatableValue<Identifier, AsciiStr
             return New(idLength, ReadOnlySpan<byte>.Empty);
         }
 
-        Span<byte> utf8 = stackalloc byte[prefix.Length];
+        Span<byte> utf8 = stackalloc byte[MaxPrefixLength];
 
         var status = Ascii.FromUtf16(prefix, utf8, out var bytesWritten);
 
         if (status is OperationStatus.Done)
         {
             Debug.Assert(bytesWritten == prefix.Length);
-            return New(idLength, utf8);
+            return New(idLength, utf8[..bytesWritten]);
         }
 
         Debug.Assert(status is OperationStatus.InvalidData);
@@ -208,11 +208,11 @@ public readonly partial struct Identifier : IEquatableValue<Identifier, AsciiStr
             id.Span[idStartIndex - 1] = (AsciiChar)'_';
         }
 
-        Span<byte> randomBuffer = stackalloc byte[idLength * 2];
+        Span<byte> randomBuffer = stackalloc byte[MaxIdLength * 2];
 
         RandomNumberGenerator.Fill(randomBuffer);
 
-        for (var i = 0; i < randomBuffer.Length; i += 2)
+        for (var i = 0; i < idLength * 2; i += 2)
         {
             var f = BitConverter.ToUInt16(randomBuffer.Slice(i, 2));
             var c = f % ValidIdBytes.Length;

--- a/src/DSE.Open.Values/UriAsciiPath.cs
+++ b/src/DSE.Open.Values/UriAsciiPath.cs
@@ -261,17 +261,13 @@ public readonly partial struct UriAsciiPath
         var rented = SpanOwner<byte>.Empty;
 
         Span<byte> buffer = MemoryThresholds.CanStackalloc<byte>(value.Length)
-            ? stackalloc byte[value.Length]
+            ? stackalloc byte[MemoryThresholds.StackallocCharThreshold]
             : (rented = SpanOwner<byte>.Allocate(value.Length)).Span;
 
         using (rented)
         {
-            if (NarrowUtf16ToAscii(value, buffer))
-            {
-                return IsValidValue(ValuesMarshal.AsAsciiChars(buffer[..value.Length]));
-            }
-
-            return false;
+            return NarrowUtf16ToAscii(value, buffer)
+                && IsValidValue(ValuesMarshal.AsAsciiChars(buffer[..value.Length]));
         }
     }
 
@@ -326,7 +322,7 @@ public readonly partial struct UriAsciiPath
             var rented = SpanOwner<char>.Empty;
 
             Span<char> buffer = MemoryThresholds.CanStackalloc<char>(s.Length)
-                ? stackalloc char[s.Length]
+                ? stackalloc char[MemoryThresholds.StackallocCharThreshold]
                 : (rented = SpanOwner<char>.Allocate(s.Length)).Span;
 
             using (rented)

--- a/src/DSE.Open/AsciiString.cs
+++ b/src/DSE.Open/AsciiString.cs
@@ -153,7 +153,7 @@ public readonly struct AsciiString
         var rented = SpanOwner<byte>.Empty;
 
         Span<byte> buffer = MemoryThresholds.CanStackalloc<byte>(s.Length)
-            ? stackalloc byte[s.Length]
+            ? stackalloc byte[MemoryThresholds.StackallocByteThreshold]
             : (rented = SpanOwner<byte>.Allocate(s.Length)).Span;
 
         using (rented)

--- a/src/DSE.Open/MemoryExtensions.AsciiChar.cs
+++ b/src/DSE.Open/MemoryExtensions.AsciiChar.cs
@@ -41,7 +41,7 @@ public static partial class MemoryExtensions
         char[]? rented = null;
 
         Span<char> buffer = MemoryThresholds.CanStackalloc<char>(span.Length)
-            ? stackalloc char[span.Length]
+            ? stackalloc char[MemoryThresholds.StackallocCharThreshold]
             : (rented = ArrayPool<char>.Shared.Rent(span.Length));
 
         try

--- a/src/DSE.Open/Security/SecureToken.cs
+++ b/src/DSE.Open/Security/SecureToken.cs
@@ -39,20 +39,20 @@ public readonly record struct SecureToken : ISpanParsable<SecureToken>, ISpanFor
             throw new ArgumentOutOfRangeException(nameof(length));
         }
 
-        Span<byte> data = stackalloc byte[length * 2];
+        Span<byte> data = stackalloc byte[MaxTokenLength];
 
         RandomNumberGenerator.Fill(data);
 
-        Span<char> id = stackalloc char[data.Length / 2];
+        Span<char> id = stackalloc char[MaxTokenLength / 2];
 
-        for (var i = 0; i < data.Length; i += 2)
+        for (var i = 0; i < length * 2; i += 2)
         {
             var f = MemoryMarshal.Read<ushort>(data.Slice(i, 2));
             var c = f % TokenChars.Length;
             id[i / 2] = TokenChars.Span[c];
         }
 
-        return new(id.ToArray());
+        return new(id[..length].ToArray());
     }
 
     public ReadOnlySpan<char> AsSpan()


### PR DESCRIPTION
Codegen is much better when stack allocating fixed sized spans. There are some more but these seemed like the most-used paths.