### PR TITLE
Rework observations classes to better interact with Json source generated serialization

### DIFF
--- a/src/DSE.Open.Observations.Abstractions/Measure.cs
+++ b/src/DSE.Open.Observations.Abstractions/Measure.cs
@@ -9,38 +9,28 @@ namespace DSE.Open.Observations;
 /// <summary>
 /// A measure defines what the value of an observation refers to.
 /// </summary>
-public abstract record Measure : ImmutableDataTransferObject, IEquatable<Measure>
+public abstract record Measure : ImmutableDataTransferObject
 {
-    [JsonConstructor]
-    protected Measure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-    {
-        Id = id;
-        Uri = uri;
-        MeasurementLevel = measurementLevel;
-        Name = name;
-        Statement = statement;
-    }
-
     /// <summary>
     /// An identifier for the measure. This is generated from a hash of the <see cref="Uri" />.
     /// </summary>
     [JsonPropertyName("id")]
-    public MeasureId Id { get; }
+    public required MeasureId Id { get; init; }
 
     /// <summary>
     /// A URI that uniquely identifies the measure.
     /// </summary>
     [JsonPropertyName("uri")]
-    public Uri Uri { get; }
+    public required Uri Uri { get; init; }
 
     [JsonPropertyName("level")]
-    public MeasurementLevel MeasurementLevel { get; }
+    public required MeasurementLevel MeasurementLevel { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; }
+    public required string Name { get; init; }
 
     [JsonPropertyName("statement")]
-    public string Statement { get; }
+    public required string Statement { get; init; }
 
     public virtual bool Equals(Measure? other)
     {
@@ -57,12 +47,6 @@ public abstract record Measure<TObs, TValue> : Measure
     where TObs : Observation<TValue>
     where TValue : IEquatable<TValue>
 {
-    [JsonConstructor]
-    protected Measure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-    }
-
     public TObs CreateObservation(TValue value)
     {
         return CreateObservation(value, TimeProvider.System);
@@ -84,12 +68,6 @@ public abstract record Measure<TObs, TValue, TDisc> : Measure
     where TValue : IEquatable<TValue>
     where TDisc : IEquatable<TDisc>
 {
-    [JsonConstructor]
-    protected Measure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-    }
-
     public TObs CreateObservation(TDisc discriminator, TValue value)
     {
         return CreateObservation(discriminator, value, TimeProvider.System);

--- a/src/DSE.Open.Observations/AmountMeasure.cs
+++ b/src/DSE.Open.Observations/AmountMeasure.cs
@@ -1,23 +1,21 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record AmountMeasure : Measure<AmountObservation, Amount>
 {
+    [SetsRequiredMembers]
     public AmountMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Amount, name, statement)
     {
-    }
-
-    [JsonConstructor]
-    internal AmountMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Amount);
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Amount;
+        Name = name;
+        Statement = statement;
     }
 
     public override AmountObservation CreateObservation(Amount value, DateTimeOffset timestamp)

--- a/src/DSE.Open.Observations/AmountObservation.cs
+++ b/src/DSE.Open.Observations/AmountObservation.cs
@@ -1,26 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public record AmountObservation : Observation<Amount>
 {
-    protected AmountObservation(Measure measure, DateTimeOffset time, Amount value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal AmountObservation(ObservationId id, MeasureId measureId, long timestamp, Amount value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static AmountObservation Create(Measure measure, Amount value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -31,8 +17,14 @@ public record AmountObservation : Observation<Amount>
         Amount value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new AmountObservation(measure, timeProvider.GetUtcNow(), value);
+        return new AmountObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/AmountObservationSet.cs
+++ b/src/DSE.Open.Observations/AmountObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record AmountObservationSet : ObservationSet<AmountObservation, Amount>
 {
-    public AmountObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<AmountObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal AmountObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<AmountObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static AmountObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record AmountObservationSet : ObservationSet<AmountObservation, Am
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new AmountObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new AmountObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/AmountSnapshot.cs
+++ b/src/DSE.Open.Observations/AmountSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record AmountSnapshot : Snapshot<AmountObservation, Amount>
 {
-    [JsonConstructor]
-    internal AmountSnapshot(DateTimeOffset time, AmountObservation observation) : base(time, observation)
-    {
-    }
-
     public static AmountSnapshot ForUtcNow(AmountObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record AmountSnapshot : Snapshot<AmountObservation, Amount>
 
     public static AmountSnapshot ForUtcNow(AmountObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new AmountSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new AmountSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/AmountSnapshotSet.cs
+++ b/src/DSE.Open.Observations/AmountSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,37 +8,6 @@ namespace DSE.Open.Observations;
 
 public record AmountSnapshotSet : SnapshotSet<AmountSnapshot, AmountObservation, Amount>
 {
-    protected AmountSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<AmountSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected AmountSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<AmountSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal AmountSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<AmountSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static AmountSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<AmountSnapshot> snapshots)
@@ -58,6 +25,13 @@ public record AmountSnapshotSet : SnapshotSet<AmountSnapshot, AmountObservation,
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new AmountSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new AmountSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/BehaviorFrequencyMeasure.cs
+++ b/src/DSE.Open.Observations/BehaviorFrequencyMeasure.cs
@@ -1,22 +1,20 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DSE.Open.Observations;
 
 public sealed record BehaviorFrequencyMeasure : Measure<BehaviorFrequencyObservation, BehaviorFrequency>
 {
+    [SetsRequiredMembers]
     public BehaviorFrequencyMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.GradedMembership, name, statement)
     {
-    }
-
-    [JsonConstructor]
-    internal BehaviorFrequencyMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.GradedMembership);
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.GradedMembership;
+        Name = name;
+        Statement = statement;
     }
 
     public override BehaviorFrequencyObservation CreateObservation(BehaviorFrequency value, DateTimeOffset timestamp)

--- a/src/DSE.Open.Observations/BehaviorFrequencyObservation.cs
+++ b/src/DSE.Open.Observations/BehaviorFrequencyObservation.cs
@@ -1,25 +1,10 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public record BehaviorFrequencyObservation : Observation<BehaviorFrequency>
 {
-    protected BehaviorFrequencyObservation(Measure measure, DateTimeOffset time, BehaviorFrequency value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BehaviorFrequencyObservation(ObservationId id, MeasureId measureId, long timestamp, BehaviorFrequency value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static BehaviorFrequencyObservation Create(Measure measure, BehaviorFrequency value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -30,8 +15,14 @@ public record BehaviorFrequencyObservation : Observation<BehaviorFrequency>
         BehaviorFrequency value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BehaviorFrequencyObservation(measure, timeProvider.GetUtcNow(), value);
+        return new BehaviorFrequencyObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/BehaviorFrequencyObservationSet.cs
+++ b/src/DSE.Open.Observations/BehaviorFrequencyObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record BehaviorFrequencyObservationSet : ObservationSet<BehaviorFrequencyObservation, BehaviorFrequency>
 {
-    private BehaviorFrequencyObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BehaviorFrequencyObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BehaviorFrequencyObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BehaviorFrequencyObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static BehaviorFrequencyObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record BehaviorFrequencyObservationSet : ObservationSet<BehaviorFr
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BehaviorFrequencyObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new BehaviorFrequencyObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/BehaviorFrequencySnapshot.cs
+++ b/src/DSE.Open.Observations/BehaviorFrequencySnapshot.cs
@@ -1,25 +1,25 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public sealed record BehaviorFrequencySnapshot : Snapshot<BehaviorFrequencyObservation, BehaviorFrequency>
 {
-    [JsonConstructor]
-    internal BehaviorFrequencySnapshot(DateTimeOffset time, BehaviorFrequencyObservation observation) : base(time, observation)
-    {
-    }
-
     public static BehaviorFrequencySnapshot ForUtcNow(BehaviorFrequencyObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
     }
 
-    public static BehaviorFrequencySnapshot ForUtcNow(BehaviorFrequencyObservation observation, TimeProvider timeProvider)
+    public static BehaviorFrequencySnapshot ForUtcNow(
+        BehaviorFrequencyObservation observation,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new BehaviorFrequencySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new BehaviorFrequencySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/BehaviorFrequencySnapshotSet.cs
+++ b/src/DSE.Open.Observations/BehaviorFrequencySnapshotSet.cs
@@ -1,8 +1,6 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,37 +8,6 @@ namespace DSE.Open.Observations;
 
 public record BehaviorFrequencySnapshotSet : SnapshotSet<BehaviorFrequencySnapshot, BehaviorFrequencyObservation, BehaviorFrequency>
 {
-    protected BehaviorFrequencySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BehaviorFrequencySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected BehaviorFrequencySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BehaviorFrequencySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BehaviorFrequencySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BehaviorFrequencySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static BehaviorFrequencySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<BehaviorFrequencySnapshot> snapshots)
@@ -58,6 +25,13 @@ public record BehaviorFrequencySnapshotSet : SnapshotSet<BehaviorFrequencySnapsh
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new BehaviorFrequencySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new BehaviorFrequencySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinaryMeasure.cs
+++ b/src/DSE.Open.Observations/BinaryMeasure.cs
@@ -1,23 +1,22 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinaryMeasure : Measure<BinaryObservation, bool>
 {
+    [SetsRequiredMembers]
     public BinaryMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal BinaryMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
 
     public override BinaryObservation CreateObservation(bool value, DateTimeOffset timestamp)
     {

--- a/src/DSE.Open.Observations/BinaryObservation.cs
+++ b/src/DSE.Open.Observations/BinaryObservation.cs
@@ -1,25 +1,10 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public record BinaryObservation : Observation<bool>
 {
-    protected BinaryObservation(Measure measure, DateTimeOffset time, bool value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinaryObservation(ObservationId id, MeasureId measureId, long timestamp, bool value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static BinaryObservation Create(Measure measure, bool value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -30,8 +15,14 @@ public record BinaryObservation : Observation<bool>
         bool value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinaryObservation(measure, timeProvider.GetUtcNow(), value);
+        return new BinaryObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinaryObservationSet.cs
+++ b/src/DSE.Open.Observations/BinaryObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record BinaryObservationSet : ObservationSet<BinaryObservation, bool>
 {
-    private BinaryObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinaryObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinaryObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinaryObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static BinaryObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record BinaryObservationSet : ObservationSet<BinaryObservation, bo
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinaryObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new BinaryObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySentenceMeasure.cs
+++ b/src/DSE.Open.Observations/BinarySentenceMeasure.cs
@@ -1,29 +1,25 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinarySentenceMeasure : Measure<BinarySentenceObservation, bool, SentenceId>
 {
+    [SetsRequiredMembers]
     public BinarySentenceMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal BinarySentenceMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
+    public override BinarySentenceObservation CreateObservation(SentenceId sentenceId, bool value, DateTimeOffset timestamp)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override BinarySentenceObservation CreateObservation(SentenceId wordId, bool value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
-    {
-        return BinarySentenceObservation.Create(this, wordId, value, TimeProvider.System);
+        return BinarySentenceObservation.Create(this, sentenceId, value, TimeProvider.System);
     }
 }

--- a/src/DSE.Open.Observations/BinarySentenceObservation.cs
+++ b/src/DSE.Open.Observations/BinarySentenceObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
@@ -9,18 +8,6 @@ namespace DSE.Open.Observations;
 
 public record BinarySentenceObservation : Observation<bool, SentenceId>
 {
-    protected BinarySentenceObservation(Measure measure, SentenceId discriminator, DateTimeOffset time, bool value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinarySentenceObservation(ObservationId id, MeasureId measureId, SentenceId discriminator, long timestamp, bool value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SentenceId SentenceId => Discriminator;
 
@@ -35,9 +22,16 @@ public record BinarySentenceObservation : Observation<bool, SentenceId>
         bool value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinarySentenceObservation(measure, sentenceId, timeProvider.GetUtcNow(), value);
+        return new BinarySentenceObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = sentenceId
+        };
     }
 
     protected override ulong GetDiscriminatorId()

--- a/src/DSE.Open.Observations/BinarySentenceObservationSet.cs
+++ b/src/DSE.Open.Observations/BinarySentenceObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record BinarySentenceObservationSet : ObservationSet<BinarySentenceObservation, bool>
 {
-    internal BinarySentenceObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinarySentenceObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinarySentenceObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinarySentenceObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static BinarySentenceObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record BinarySentenceObservationSet : ObservationSet<BinarySentenc
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinarySentenceObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new BinarySentenceObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySentenceSnapshot.cs
+++ b/src/DSE.Open.Observations/BinarySentenceSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinarySentenceSnapshot : Snapshot<BinarySentenceObservation, bool, SentenceId>
 {
-    [JsonConstructor]
-    internal BinarySentenceSnapshot(DateTimeOffset time, BinarySentenceObservation observation) : base(time, observation)
-    {
-    }
-
     public static BinarySentenceSnapshot ForUtcNow(BinarySentenceObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record BinarySentenceSnapshot : Snapshot<BinarySentenceObservation
 
     public static BinarySentenceSnapshot ForUtcNow(BinarySentenceObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new BinarySentenceSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new BinarySentenceSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySentenceSnapshotSet.cs
+++ b/src/DSE.Open.Observations/BinarySentenceSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,37 +10,6 @@ namespace DSE.Open.Observations;
 public record BinarySentenceSnapshotSet
     : SnapshotSet<BinarySentenceSnapshot, BinarySentenceObservation, bool, SentenceId>
 {
-    protected BinarySentenceSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySentenceSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected BinarySentenceSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySentenceSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinarySentenceSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySentenceSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static BinarySentenceSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<BinarySentenceSnapshot> snapshots)
@@ -60,6 +27,13 @@ public record BinarySentenceSnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new BinarySentenceSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new BinarySentenceSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySnapshot.cs
+++ b/src/DSE.Open.Observations/BinarySnapshot.cs
@@ -1,17 +1,10 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public sealed record BinarySnapshot : Snapshot<BinaryObservation, bool>
 {
-    [JsonConstructor]
-    internal BinarySnapshot(DateTimeOffset time, BinaryObservation observation) : base(time, observation)
-    {
-    }
-
     public static BinarySnapshot ForUtcNow(BinaryObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,6 +13,11 @@ public sealed record BinarySnapshot : Snapshot<BinaryObservation, bool>
     public static BinarySnapshot ForUtcNow(BinaryObservation observation, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new BinarySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new BinarySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySnapshotSet.cs
+++ b/src/DSE.Open.Observations/BinarySnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,37 +8,6 @@ namespace DSE.Open.Observations;
 
 public record BinarySnapshotSet : SnapshotSet<BinarySnapshot, BinaryObservation, bool>
 {
-    protected BinarySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected BinarySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected BinarySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static BinarySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<BinarySnapshot> snapshots)
@@ -58,6 +25,13 @@ public record BinarySnapshotSet : SnapshotSet<BinarySnapshot, BinaryObservation,
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new BinarySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new BinarySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySpeechSoundMeasure.cs
+++ b/src/DSE.Open.Observations/BinarySpeechSoundMeasure.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinarySpeechSoundMeasure : Measure<BinarySpeechSoundObservation, bool, SpeechSound>
 {
+    [SetsRequiredMembers]
     public BinarySpeechSoundMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal BinarySpeechSoundMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
     public override BinarySpeechSoundObservation CreateObservation(SpeechSound speechSound, bool value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
     {
         return BinarySpeechSoundObservation.Create(this, speechSound, value, TimeProvider.System);
     }

--- a/src/DSE.Open.Observations/BinarySpeechSoundObservation.cs
+++ b/src/DSE.Open.Observations/BinarySpeechSoundObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,18 +11,6 @@ namespace DSE.Open.Observations;
 
 public record BinarySpeechSoundObservation : Observation<bool, SpeechSound>
 {
-    protected BinarySpeechSoundObservation(Measure measure, SpeechSound discriminator, DateTimeOffset time, bool value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinarySpeechSoundObservation(ObservationId id, MeasureId measureId, SpeechSound discriminator, long timestamp, bool value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SpeechSound SpeechSound => Discriminator;
 
@@ -38,9 +25,16 @@ public record BinarySpeechSoundObservation : Observation<bool, SpeechSound>
         bool value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinarySpeechSoundObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new BinarySpeechSoundObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = speechSound
+        };
     }
 
     [SkipLocalsInit]

--- a/src/DSE.Open.Observations/BinarySpeechSoundObservationSet.cs
+++ b/src/DSE.Open.Observations/BinarySpeechSoundObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record BinarySpeechSoundObservationSet : ObservationSet<BinarySpeechSoundObservation, bool>
 {
-    internal BinarySpeechSoundObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinarySpeechSoundObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinarySpeechSoundObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinarySpeechSoundObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static BinarySpeechSoundObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record BinarySpeechSoundObservationSet : ObservationSet<BinarySpee
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinarySpeechSoundObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new BinarySpeechSoundObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySpeechSoundSnapshot.cs
+++ b/src/DSE.Open.Observations/BinarySpeechSoundSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinarySpeechSoundSnapshot : Snapshot<BinarySpeechSoundObservation, bool, SpeechSound>
 {
-    [JsonConstructor]
-    internal BinarySpeechSoundSnapshot(DateTimeOffset time, BinarySpeechSoundObservation observation) : base(time, observation)
-    {
-    }
-
     public static BinarySpeechSoundSnapshot ForUtcNow(BinarySpeechSoundObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record BinarySpeechSoundSnapshot : Snapshot<BinarySpeechSoundObser
 
     public static BinarySpeechSoundSnapshot ForUtcNow(BinarySpeechSoundObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new BinarySpeechSoundSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new BinarySpeechSoundSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation,
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinarySpeechSoundSnapshotSet.cs
+++ b/src/DSE.Open.Observations/BinarySpeechSoundSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Speech;
 using DSE.Open.Values;
@@ -12,37 +10,6 @@ namespace DSE.Open.Observations;
 public record BinarySpeechSoundSnapshotSet
     : SnapshotSet<BinarySpeechSoundSnapshot, BinarySpeechSoundObservation, bool, SpeechSound>
 {
-    protected BinarySpeechSoundSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySpeechSoundSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected BinarySpeechSoundSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySpeechSoundSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected BinarySpeechSoundSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinarySpeechSoundSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static BinarySpeechSoundSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<BinarySpeechSoundSnapshot> snapshots)
@@ -60,6 +27,13 @@ public record BinarySpeechSoundSnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new BinarySpeechSoundSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new BinarySpeechSoundSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinaryWordMeasure.cs
+++ b/src/DSE.Open.Observations/BinaryWordMeasure.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinaryWordMeasure : Measure<BinaryWordObservation, bool, WordId>
 {
+    [SetsRequiredMembers]
     public BinaryWordMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal BinaryWordMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
     public override BinaryWordObservation CreateObservation(WordId wordId, bool value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
     {
         return BinaryWordObservation.Create(this, wordId, value, TimeProvider.System);
     }

--- a/src/DSE.Open.Observations/BinaryWordObservation.cs
+++ b/src/DSE.Open.Observations/BinaryWordObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
@@ -9,18 +8,6 @@ namespace DSE.Open.Observations;
 
 public record BinaryWordObservation : Observation<bool, WordId>
 {
-    protected BinaryWordObservation(Measure measure, WordId discriminator, DateTimeOffset time, bool value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinaryWordObservation(ObservationId id, MeasureId measureId, WordId discriminator, long timestamp, bool value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public WordId WordId => Discriminator;
 
@@ -35,9 +22,16 @@ public record BinaryWordObservation : Observation<bool, WordId>
         bool value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinaryWordObservation(measure, wordId, timeProvider.GetUtcNow(), value);
+        return new BinaryWordObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = wordId
+        };
     }
 
     protected override ulong GetDiscriminatorId()

--- a/src/DSE.Open.Observations/BinaryWordObservationSet.cs
+++ b/src/DSE.Open.Observations/BinaryWordObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record BinaryWordObservationSet : ObservationSet<BinaryWordObservation, bool>
 {
-    internal BinaryWordObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinaryWordObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal BinaryWordObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<BinaryWordObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static BinaryWordObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record BinaryWordObservationSet : ObservationSet<BinaryWordObserva
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new BinaryWordObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new BinaryWordObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinaryWordSnapshot.cs
+++ b/src/DSE.Open.Observations/BinaryWordSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record BinaryWordSnapshot : Snapshot<BinaryWordObservation, bool, WordId>
 {
-    [JsonConstructor]
-    internal BinaryWordSnapshot(DateTimeOffset time, BinaryWordObservation observation) : base(time, observation)
-    {
-    }
-
     public static BinaryWordSnapshot ForUtcNow(BinaryWordObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -21,6 +15,11 @@ public sealed record BinaryWordSnapshot : Snapshot<BinaryWordObservation, bool, 
     public static BinaryWordSnapshot ForUtcNow(BinaryWordObservation observation, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new BinaryWordSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new BinaryWordSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/BinaryWordSnapshotSet.cs
+++ b/src/DSE.Open.Observations/BinaryWordSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,37 +10,6 @@ namespace DSE.Open.Observations;
 public record BinaryWordSnapshotSet
     : SnapshotSet<BinaryWordSnapshot, BinaryWordObservation, bool, WordId>
 {
-    protected BinaryWordSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinaryWordSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected BinaryWordSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinaryWordSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected BinaryWordSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<BinaryWordSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static BinaryWordSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<BinaryWordSnapshot> snapshots)
@@ -60,6 +27,13 @@ public record BinaryWordSnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new BinaryWordSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new BinaryWordSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/CompletenessMeasure.cs
+++ b/src/DSE.Open.Observations/CompletenessMeasure.cs
@@ -1,22 +1,20 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DSE.Open.Observations;
 
 public sealed record CompletenessMeasure : Measure<CompletenessObservation, Completeness>
 {
+    [SetsRequiredMembers]
     public CompletenessMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.GradedMembership, name, statement)
     {
-    }
-
-    [JsonConstructor]
-    internal CompletenessMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.GradedMembership);
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.GradedMembership;
+        Name = name;
+        Statement = statement;
     }
 
     public override CompletenessObservation CreateObservation(Completeness value, DateTimeOffset timestamp)

--- a/src/DSE.Open.Observations/CompletenessObservation.cs
+++ b/src/DSE.Open.Observations/CompletenessObservation.cs
@@ -1,25 +1,10 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public record CompletenessObservation : Observation<Completeness>
 {
-    protected CompletenessObservation(Measure measure, DateTimeOffset time, Completeness value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal CompletenessObservation(ObservationId id, MeasureId measureId, long timestamp, Completeness value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static CompletenessObservation Create(Measure measure, Completeness value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -30,8 +15,14 @@ public record CompletenessObservation : Observation<Completeness>
         Completeness value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new CompletenessObservation(measure, timeProvider.GetUtcNow(), value);
+        return new CompletenessObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/CompletenessObservationSet.cs
+++ b/src/DSE.Open.Observations/CompletenessObservationSet.cs
@@ -1,8 +1,6 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record CompletenessObservationSet : ObservationSet<CompletenessObservation, Completeness>
 {
-    private CompletenessObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<CompletenessObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal CompletenessObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<CompletenessObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static CompletenessObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record CompletenessObservationSet : ObservationSet<CompletenessObs
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new CompletenessObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new CompletenessObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/CountMeasure.cs
+++ b/src/DSE.Open.Observations/CountMeasure.cs
@@ -1,23 +1,21 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record CountMeasure : Measure<CountObservation, Count>
 {
+    [SetsRequiredMembers]
     public CountMeasure(MeasureId id, Uri uri, string name, string statement)
-        : this(id, uri, MeasurementLevel.Count, name, statement)
     {
-    }
-
-    [JsonConstructor]
-    internal CountMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Count);
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Count;
+        Name = name;
+        Statement = statement;
     }
 
     public override CountObservation CreateObservation(Count value, DateTimeOffset timestamp)

--- a/src/DSE.Open.Observations/CountObservation.cs
+++ b/src/DSE.Open.Observations/CountObservation.cs
@@ -1,26 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public record CountObservation : Observation<Count>
 {
-    protected CountObservation(Measure measure, DateTimeOffset time, Count value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal CountObservation(ObservationId id, MeasureId measureId, long timestamp, Count value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static CountObservation Create(Measure measure, Count value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -31,8 +17,14 @@ public record CountObservation : Observation<Count>
         Count value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new CountObservation(measure, timeProvider.GetUtcNow(), value);
+        return new CountObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/CountObservationSet.cs
+++ b/src/DSE.Open.Observations/CountObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record CountObservationSet : ObservationSet<CountObservation, Count>
 {
-    internal CountObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<CountObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal CountObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<CountObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static CountObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record CountObservationSet : ObservationSet<CountObservation, Coun
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new CountObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new CountObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/CountSnapshot.cs
+++ b/src/DSE.Open.Observations/CountSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record CountSnapshot : Snapshot<CountObservation, Count>
 {
-    [JsonConstructor]
-    internal CountSnapshot(DateTimeOffset time, CountObservation observation) : base(time, observation)
-    {
-    }
-
     public static CountSnapshot ForUtcNow(CountObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record CountSnapshot : Snapshot<CountObservation, Count>
 
     public static CountSnapshot ForUtcNow(CountObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new CountSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new CountSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/CountSnapshotSet.cs
+++ b/src/DSE.Open.Observations/CountSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,37 +8,6 @@ namespace DSE.Open.Observations;
 
 public record CountSnapshotSet : SnapshotSet<CountSnapshot, CountObservation, Count>
 {
-    protected CountSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<CountSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected CountSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<CountSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal CountSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<CountSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static CountSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<CountSnapshot> snapshots)
@@ -58,6 +25,13 @@ public record CountSnapshotSet : SnapshotSet<CountSnapshot, CountObservation, Co
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new CountSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new CountSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/Properties/AssemblyInfo.cs
+++ b/src/DSE.Open.Observations/Properties/AssemblyInfo.cs
@@ -1,7 +1,2 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("DSE.Open.Observations.Tests")]
-

--- a/src/DSE.Open.Observations/RatioMeasure.cs
+++ b/src/DSE.Open.Observations/RatioMeasure.cs
@@ -1,19 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record RatioMeasure : Measure<RatioObservation, Ratio>
 {
-    [JsonConstructor]
-    public RatioMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-    }
-
     public override RatioObservation CreateObservation(Ratio value, DateTimeOffset timestamp)
     {
         return RatioObservation.Create(this, value, TimeProvider.System);

--- a/src/DSE.Open.Observations/RatioObservation.cs
+++ b/src/DSE.Open.Observations/RatioObservation.cs
@@ -1,26 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public record RatioObservation : Observation<Ratio>
 {
-    protected RatioObservation(Measure measure, DateTimeOffset time, Ratio value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal RatioObservation(ObservationId id, MeasureId measureId, long timestamp, Ratio value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static RatioObservation Create(Measure measure, Ratio value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -31,8 +17,14 @@ public record RatioObservation : Observation<Ratio>
         Ratio value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new RatioObservation(measure, timeProvider.GetUtcNow(), value);
+        return new RatioObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/RatioObservationSet.cs
+++ b/src/DSE.Open.Observations/RatioObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,31 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record RatioObservationSet : ObservationSet<RatioObservation, Ratio>
 {
-    internal RatioObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<RatioObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal RatioObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<RatioObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static RatioObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -68,6 +41,14 @@ public sealed record RatioObservationSet : ObservationSet<RatioObservation, Rati
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new RatioObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new RatioObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/RatioSnapshot.cs
+++ b/src/DSE.Open.Observations/RatioSnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 public sealed record RatioSnapshot : Snapshot<RatioObservation, Ratio>
 {
-    [JsonConstructor]
-    internal RatioSnapshot(DateTimeOffset time, RatioObservation observation) : base(time, observation)
-    {
-    }
-
     public static RatioSnapshot ForUtcNow(RatioObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record RatioSnapshot : Snapshot<RatioObservation, Ratio>
 
     public static RatioSnapshot ForUtcNow(RatioObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new RatioSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new RatioSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/RatioSnapshotSet.cs
+++ b/src/DSE.Open.Observations/RatioSnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,37 +8,6 @@ namespace DSE.Open.Observations;
 
 public record RatioSnapshotSet : SnapshotSet<RatioSnapshot, RatioObservation, Ratio>
 {
-    protected RatioSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<RatioSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected RatioSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<RatioSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal RatioSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<RatioSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static RatioSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<RatioSnapshot> snapshots)
@@ -58,6 +25,13 @@ public record RatioSnapshotSet : SnapshotSet<RatioSnapshot, RatioObservation, Ra
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new RatioSnapshotSet(now, now, trackerReference, snapshots);
+
+        return new RatioSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceCompletenessMeasure.cs
+++ b/src/DSE.Open.Observations/SentenceCompletenessMeasure.cs
@@ -1,28 +1,24 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record SentenceCompletenessMeasure : Measure<SentenceCompletenessObservation, Completeness, SentenceId>
 {
+    [SetsRequiredMembers]
     public SentenceCompletenessMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SentenceCompletenessMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
     public override SentenceCompletenessObservation CreateObservation(SentenceId wordId, Completeness value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
     {
         return SentenceCompletenessObservation.Create(this, wordId, value, TimeProvider.System);
     }

--- a/src/DSE.Open.Observations/SentenceCompletenessObservation.cs
+++ b/src/DSE.Open.Observations/SentenceCompletenessObservation.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
@@ -9,18 +8,6 @@ namespace DSE.Open.Observations;
 
 public record SentenceCompletenessObservation : Observation<Completeness, SentenceId>
 {
-    protected SentenceCompletenessObservation(Measure measure, SentenceId discriminator, DateTimeOffset time, Completeness value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SentenceCompletenessObservation(ObservationId id, MeasureId measureId, SentenceId discriminator, long timestamp, Completeness value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SentenceId SentenceId => Discriminator;
 
@@ -35,9 +22,16 @@ public record SentenceCompletenessObservation : Observation<Completeness, Senten
         Completeness value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SentenceCompletenessObservation(measure, sentenceId, timeProvider.GetUtcNow(), value);
+        return new SentenceCompletenessObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = sentenceId
+        };
     }
 
     protected override ulong GetDiscriminatorId()

--- a/src/DSE.Open.Observations/SentenceCompletenessObservationSet.cs
+++ b/src/DSE.Open.Observations/SentenceCompletenessObservationSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record SentenceCompletenessObservationSet : ObservationSet<SentenceCompletenessObservation, Completeness>
 {
-    internal SentenceCompletenessObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SentenceCompletenessObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SentenceCompletenessObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SentenceCompletenessObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SentenceCompletenessObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record SentenceCompletenessObservationSet : ObservationSet<Sentenc
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SentenceCompletenessObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SentenceCompletenessObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceCompletenessSnapshot.cs
+++ b/src/DSE.Open.Observations/SentenceCompletenessSnapshot.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record SentenceCompletenessSnapshot : Snapshot<SentenceCompletenessObservation, Completeness, SentenceId>
 {
-    [JsonConstructor]
-    internal SentenceCompletenessSnapshot(DateTimeOffset time, SentenceCompletenessObservation observation) : base(time, observation)
-    {
-    }
-
     public static SentenceCompletenessSnapshot ForUtcNow(SentenceCompletenessObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record SentenceCompletenessSnapshot : Snapshot<SentenceCompletenes
 
     public static SentenceCompletenessSnapshot ForUtcNow(SentenceCompletenessObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SentenceCompletenessSnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SentenceCompletenessSnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceCompletenessSnapshotSet.cs
+++ b/src/DSE.Open.Observations/SentenceCompletenessSnapshotSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record SentenceCompletenessSnapshotSet
     : SnapshotSet<SentenceCompletenessSnapshot, SentenceCompletenessObservation, Completeness, SentenceId>
 {
-    protected SentenceCompletenessSnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceCompletenessSnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SentenceCompletenessSnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceCompletenessSnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SentenceCompletenessSnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceCompletenessSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SentenceCompletenessSnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SentenceCompletenessSnapshot> snapshots)
@@ -61,6 +27,12 @@ public record SentenceCompletenessSnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SentenceCompletenessSnapshotSet(now, now, trackerReference, snapshots);
+        return new SentenceCompletenessSnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceFrequencyMeasure.cs
+++ b/src/DSE.Open.Observations/SentenceFrequencyMeasure.cs
@@ -1,7 +1,7 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
@@ -11,22 +11,18 @@ namespace DSE.Open.Observations;
 /// </summary>
 public sealed record SentenceFrequencyMeasure : Measure<SentenceFrequencyObservation, BehaviorFrequency, SentenceId>
 {
+    [SetsRequiredMembers]
     public SentenceFrequencyMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SentenceFrequencyMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
+    public override SentenceFrequencyObservation CreateObservation(SentenceId sentenceId, BehaviorFrequency value, DateTimeOffset timestamp)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override SentenceFrequencyObservation CreateObservation(SentenceId speechSound, BehaviorFrequency value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
-    {
-        return SentenceFrequencyObservation.Create(this, speechSound, value, TimeProvider.System);
+        return SentenceFrequencyObservation.Create(this, sentenceId, value, TimeProvider.System);
     }
 }

--- a/src/DSE.Open.Observations/SentenceFrequencyObservation.cs
+++ b/src/DSE.Open.Observations/SentenceFrequencyObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -15,36 +14,30 @@ namespace DSE.Open.Observations;
 /// </summary>
 public record SentenceFrequencyObservation : Observation<BehaviorFrequency, SentenceId>
 {
-    protected SentenceFrequencyObservation(Measure measure, SentenceId discriminator, DateTimeOffset time, BehaviorFrequency value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SentenceFrequencyObservation(ObservationId id, MeasureId measureId, SentenceId discriminator, long timestamp, BehaviorFrequency value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SentenceId SentenceId => Discriminator;
 
-    public static SentenceFrequencyObservation Create(Measure measure, SentenceId speechSound, BehaviorFrequency value)
+    public static SentenceFrequencyObservation Create(Measure measure, SentenceId sentenceId, BehaviorFrequency value)
     {
-        return Create(measure, speechSound, value, TimeProvider.System);
+        return Create(measure, sentenceId, value, TimeProvider.System);
     }
 
     public static SentenceFrequencyObservation Create(
         Measure measure,
-        SentenceId speechSound,
+        SentenceId sentenceId,
         BehaviorFrequency value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SentenceFrequencyObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new SentenceFrequencyObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = sentenceId
+        };
     }
 
     [SkipLocalsInit]

--- a/src/DSE.Open.Observations/SentenceFrequencyObservationSet.cs
+++ b/src/DSE.Open.Observations/SentenceFrequencyObservationSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record SentenceFrequencyObservationSet : ObservationSet<SentenceFrequencyObservation, BehaviorFrequency>
 {
-    internal SentenceFrequencyObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SentenceFrequencyObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SentenceFrequencyObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SentenceFrequencyObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SentenceFrequencyObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record SentenceFrequencyObservationSet : ObservationSet<SentenceFr
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SentenceFrequencyObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SentenceFrequencyObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceFrequencySnapshot.cs
+++ b/src/DSE.Open.Observations/SentenceFrequencySnapshot.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record SentenceFrequencySnapshot : Snapshot<SentenceFrequencyObservation, BehaviorFrequency, SentenceId>
 {
-    [JsonConstructor]
-    internal SentenceFrequencySnapshot(DateTimeOffset time, SentenceFrequencyObservation observation) : base(time, observation)
-    {
-    }
-
     public static SentenceFrequencySnapshot ForUtcNow(SentenceFrequencyObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record SentenceFrequencySnapshot : Snapshot<SentenceFrequencyObser
 
     public static SentenceFrequencySnapshot ForUtcNow(SentenceFrequencyObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SentenceFrequencySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SentenceFrequencySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SentenceFrequencySnapshotSet.cs
+++ b/src/DSE.Open.Observations/SentenceFrequencySnapshotSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record SentenceFrequencySnapshotSet
     : SnapshotSet<SentenceFrequencySnapshot, SentenceFrequencyObservation, BehaviorFrequency, SentenceId>
 {
-    protected SentenceFrequencySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceFrequencySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SentenceFrequencySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceFrequencySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SentenceFrequencySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SentenceFrequencySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SentenceFrequencySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SentenceFrequencySnapshot> snapshots)
@@ -61,6 +27,13 @@ public record SentenceFrequencySnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SentenceFrequencySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new SentenceFrequencySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SnapshotSet.cs
+++ b/src/DSE.Open.Observations/SnapshotSet.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
+using DSE.Open.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
@@ -17,70 +17,38 @@ namespace DSE.Open.Observations;
 [JsonDerivedType(typeof(BinarySpeechSoundSnapshotSet), typeDiscriminator: Schemas.BinarySpeechSoundSnapshotSet)]
 public abstract record SnapshotSet
 {
-    protected SnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference)
-        : this(Identifier.New(36, "snp"u8), created, updated, trackerReference)
-    {
-    }
+    private readonly DateTimeOffset _created;
+    private readonly DateTimeOffset _updated;
 
-    protected SnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference)
-    {
-        Id = id;
-        CreatedTimestamp = created.ToUnixTimeMilliseconds();
-        UpdatedTimestamp = updated.ToUnixTimeMilliseconds();
-        TrackerReference = trackerReference;
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference)
-    {
-        Id = id;
-        CreatedTimestamp = createdTimestamp;
-        UpdatedTimestamp = updatedTimestamp;
-        TrackerReference = trackerReference;
-    }
-
-    /// <summary>
-    /// A randomly generated number between 0 and <see cref="NumberHelper.MaxJsonSafeInteger"/> that,
-    /// together with the timestamp, uniquely identifies this observation set.
-    /// </summary>
     [JsonInclude]
     [JsonPropertyName("id")]
     [JsonPropertyOrder(-98000)]
-    public Identifier Id { get; }
-
-    [JsonIgnore]
-    public DateTimeOffset Created => DateTimeOffset.FromUnixTimeMilliseconds(CreatedTimestamp);
-
-    [JsonIgnore]
-    public DateTimeOffset Updated => DateTimeOffset.FromUnixTimeMilliseconds(UpdatedTimestamp);
-
-    // this ensures equality tests are the same before/after serialization
+    public Identifier Id { get; init; } = Identifier.New(36, "snp"u8);
 
     [JsonInclude]
     [JsonPropertyName("crt")]
     [JsonPropertyOrder(-97800)]
-    protected long CreatedTimestamp { get; }
+    [JsonConverter(typeof(JsonDateTimeOffsetUnixTimeMillisecondsConverter))]
+    public required DateTimeOffset Created
+    {
+        get => _created;
+        init => _created = DateTimeOffset.FromUnixTimeMilliseconds(value.ToUnixTimeMilliseconds());
+    }
 
     [JsonInclude]
     [JsonPropertyName("upd")]
     [JsonPropertyOrder(-97800)]
-    protected long UpdatedTimestamp { get; }
+    [JsonConverter(typeof(JsonDateTimeOffsetUnixTimeMillisecondsConverter))]
+    public required DateTimeOffset Updated
+    {
+        get => _updated;
+        init => _updated = DateTimeOffset.FromUnixTimeMilliseconds(value.ToUnixTimeMilliseconds());
+    }
 
     [JsonInclude]
     [JsonPropertyName("trk")]
     [JsonPropertyOrder(-90000)]
-    public Identifier TrackerReference { get; }
+    public required Identifier TrackerReference { get; init; }
 }
 
 #pragma warning disable CA1005 // Avoid excessive parameters on generic types
@@ -90,45 +58,9 @@ public abstract record SnapshotSet<TSnapshot, TObs, TValue> : SnapshotSet
     where TObs : Observation<TValue>
     where TValue : IEquatable<TValue>
 {
-    protected SnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(created, updated, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
-    protected SnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(id, created, updated, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
     [JsonPropertyName("obs")]
     [JsonPropertyOrder(900000)]
-    public ReadOnlyValueCollection<TSnapshot> Snapshots { get; } = [];
+    public required ReadOnlyValueCollection<TSnapshot> Snapshots { get; init; } = [];
 }
 
 public abstract record SnapshotSet<TSnapshot, TObs, TValue, TDisc> : SnapshotSet
@@ -137,43 +69,7 @@ public abstract record SnapshotSet<TSnapshot, TObs, TValue, TDisc> : SnapshotSet
     where TValue : IEquatable<TValue>
     where TDisc : IEquatable<TDisc>
 {
-    protected SnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(created, updated, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
-    protected SnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(id, created, updated, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<TSnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference)
-    {
-        ArgumentNullException.ThrowIfNull(snapshots);
-        Snapshots = snapshots;
-    }
-
     [JsonPropertyName("obs")]
     [JsonPropertyOrder(900000)]
-    public ReadOnlyValueCollection<TSnapshot> Snapshots { get; } = [];
+    public required ReadOnlyValueCollection<TSnapshot> Snapshots { get; init; } = [];
 }

--- a/src/DSE.Open.Observations/SpeechClarityMeasure.cs
+++ b/src/DSE.Open.Observations/SpeechClarityMeasure.cs
@@ -1,26 +1,24 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpeechClarityMeasure : Measure<SpeechClarityObservation, SpeechClarity>
 {
+    [SetsRequiredMembers]
     public SpeechClarityMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.GradedMembership, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.GradedMembership;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SpeechClarityMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
+    public override SpeechClarityObservation CreateObservation(SpeechClarity speechClarity, DateTimeOffset timestamp)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.GradedMembership);
-    }
-
-    public override SpeechClarityObservation CreateObservation(SpeechClarity value, DateTimeOffset timestamp)
-    {
-        return SpeechClarityObservation.Create(this, value, TimeProvider.System);
+        return SpeechClarityObservation.Create(this, speechClarity, TimeProvider.System);
     }
 }

--- a/src/DSE.Open.Observations/SpeechClarityObservation.cs
+++ b/src/DSE.Open.Observations/SpeechClarityObservation.cs
@@ -1,26 +1,10 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public record SpeechClarityObservation : Observation<SpeechClarity>
 {
-    protected SpeechClarityObservation(Measure measure, DateTimeOffset time, SpeechClarity value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechClarityObservation(ObservationId id, MeasureId measureId, long timestamp, SpeechClarity value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
-
     public static SpeechClarityObservation Create(Measure measure, SpeechClarity value)
     {
         return Create(measure, value, TimeProvider.System);
@@ -31,8 +15,14 @@ public record SpeechClarityObservation : Observation<SpeechClarity>
         SpeechClarity value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechClarityObservation(measure, timeProvider.GetUtcNow(), value);
+        return new SpeechClarityObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechClarityObservationSet.cs
+++ b/src/DSE.Open.Observations/SpeechClarityObservationSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record SpeechClarityObservationSet : ObservationSet<SpeechClarityObservation, SpeechClarity>
 {
-    private SpeechClarityObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechClarityObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    private SpeechClarityObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechClarityObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SpeechClarityObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record SpeechClarityObservationSet : ObservationSet<SpeechClarityO
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechClarityObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SpeechClarityObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechClaritySnapshot.cs
+++ b/src/DSE.Open.Observations/SpeechClaritySnapshot.cs
@@ -1,17 +1,10 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace DSE.Open.Observations;
 
 public sealed record SpeechClaritySnapshot : Snapshot<SpeechClarityObservation, SpeechClarity>
 {
-    [JsonConstructor]
-    internal SpeechClaritySnapshot(DateTimeOffset time, SpeechClarityObservation observation) : base(time, observation)
-    {
-    }
-
     public static SpeechClaritySnapshot ForUtcNow(SpeechClarityObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -19,7 +12,13 @@ public sealed record SpeechClaritySnapshot : Snapshot<SpeechClarityObservation, 
 
     public static SpeechClaritySnapshot ForUtcNow(SpeechClarityObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SpeechClaritySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SpeechClaritySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechClaritySnapshotSet.cs
+++ b/src/DSE.Open.Observations/SpeechClaritySnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,38 +8,6 @@ namespace DSE.Open.Observations;
 
 public record SpeechClaritySnapshotSet : SnapshotSet<SpeechClaritySnapshot, SpeechClarityObservation, SpeechClarity>
 {
-    protected SpeechClaritySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechClaritySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SpeechClaritySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechClaritySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechClaritySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechClaritySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SpeechClaritySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SpeechClaritySnapshot> snapshots)
@@ -59,6 +25,13 @@ public record SpeechClaritySnapshotSet : SnapshotSet<SpeechClaritySnapshot, Spee
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SpeechClaritySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new SpeechClaritySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundClarityMeasure.cs
+++ b/src/DSE.Open.Observations/SpeechSoundClarityMeasure.cs
@@ -1,28 +1,27 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpeechSoundClarityMeasure : Measure<SpeechSoundClarityObservation, SpeechClarity, SpeechSound>
 {
+    [SetsRequiredMembers]
     public SpeechSoundClarityMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SpeechSoundClarityMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override SpeechSoundClarityObservation CreateObservation(SpeechSound speechSound, SpeechClarity value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
+    public override SpeechSoundClarityObservation CreateObservation(
+        SpeechSound speechSound,
+        SpeechClarity value,
+        DateTimeOffset timestamp)
     {
         return SpeechSoundClarityObservation.Create(this, speechSound, value, TimeProvider.System);
     }

--- a/src/DSE.Open.Observations/SpeechSoundClarityObservation.cs
+++ b/src/DSE.Open.Observations/SpeechSoundClarityObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,19 +11,6 @@ namespace DSE.Open.Observations;
 
 public record SpeechSoundClarityObservation : Observation<SpeechClarity, SpeechSound>
 {
-    protected SpeechSoundClarityObservation(Measure measure, SpeechSound discriminator, DateTimeOffset time, SpeechClarity value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechSoundClarityObservation(ObservationId id, MeasureId measureId, SpeechSound discriminator, long timestamp, SpeechClarity value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SpeechSound SpeechSound => Discriminator;
 
@@ -39,9 +25,16 @@ public record SpeechSoundClarityObservation : Observation<SpeechClarity, SpeechS
         SpeechClarity value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechSoundClarityObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new SpeechSoundClarityObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = speechSound
+        };
     }
 
     [SkipLocalsInit]

--- a/src/DSE.Open.Observations/SpeechSoundClarityObservationSet.cs
+++ b/src/DSE.Open.Observations/SpeechSoundClarityObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record SpeechSoundClarityObservationSet : ObservationSet<SpeechSoundClarityObservation, SpeechClarity>
 {
-    internal SpeechSoundClarityObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechSoundClarityObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SpeechSoundClarityObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechSoundClarityObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SpeechSoundClarityObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record SpeechSoundClarityObservationSet : ObservationSet<SpeechSou
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechSoundClarityObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SpeechSoundClarityObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundClaritySnapshot.cs
+++ b/src/DSE.Open.Observations/SpeechSoundClaritySnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpeechSoundClaritySnapshot : Snapshot<SpeechSoundClarityObservation, SpeechClarity, SpeechSound>
 {
-    [JsonConstructor]
-    internal SpeechSoundClaritySnapshot(DateTimeOffset time, SpeechSoundClarityObservation observation) : base(time, observation)
-    {
-    }
-
     public static SpeechSoundClaritySnapshot ForUtcNow(SpeechSoundClarityObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record SpeechSoundClaritySnapshot : Snapshot<SpeechSoundClarityObs
 
     public static SpeechSoundClaritySnapshot ForUtcNow(SpeechSoundClarityObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SpeechSoundClaritySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SpeechSoundClaritySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundClaritySnapshotSet.cs
+++ b/src/DSE.Open.Observations/SpeechSoundClaritySnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Speech;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record SpeechSoundClaritySnapshotSet
     : SnapshotSet<SpeechSoundClaritySnapshot, SpeechSoundClarityObservation, SpeechClarity, SpeechSound>
 {
-    protected SpeechSoundClaritySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundClaritySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SpeechSoundClaritySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundClaritySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechSoundClaritySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundClaritySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SpeechSoundClaritySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SpeechSoundClaritySnapshot> snapshots)
@@ -61,6 +27,13 @@ public record SpeechSoundClaritySnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SpeechSoundClaritySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new SpeechSoundClaritySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundFrequencyMeasure.cs
+++ b/src/DSE.Open.Observations/SpeechSoundFrequencyMeasure.cs
@@ -1,7 +1,7 @@
-// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
@@ -9,23 +9,23 @@ namespace DSE.Open.Observations;
 /// <summary>
 /// A measure of observed frequency relating to a speech sound.
 /// </summary>
-public sealed record SpeechSoundFrequencyMeasure : Measure<SpeechSoundFrequencyObservation, BehaviorFrequency, SpeechSound>
+public sealed record SpeechSoundFrequencyMeasure
+    : Measure<SpeechSoundFrequencyObservation, BehaviorFrequency, SpeechSound>
 {
+    [SetsRequiredMembers]
     public SpeechSoundFrequencyMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SpeechSoundFrequencyMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override SpeechSoundFrequencyObservation CreateObservation(SpeechSound speechSound, BehaviorFrequency value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
+    public override SpeechSoundFrequencyObservation CreateObservation(
+        SpeechSound speechSound,
+        BehaviorFrequency value,
+        DateTimeOffset timestamp)
     {
         return SpeechSoundFrequencyObservation.Create(this, speechSound, value, TimeProvider.System);
     }

--- a/src/DSE.Open.Observations/SpeechSoundFrequencyObservation.cs
+++ b/src/DSE.Open.Observations/SpeechSoundFrequencyObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -15,19 +14,6 @@ namespace DSE.Open.Observations;
 /// </summary>
 public record SpeechSoundFrequencyObservation : Observation<BehaviorFrequency, SpeechSound>
 {
-    protected SpeechSoundFrequencyObservation(Measure measure, SpeechSound discriminator, DateTimeOffset time, BehaviorFrequency value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechSoundFrequencyObservation(ObservationId id, MeasureId measureId, SpeechSound discriminator, long timestamp, BehaviorFrequency value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public SpeechSound SpeechSound => Discriminator;
 
@@ -42,9 +28,16 @@ public record SpeechSoundFrequencyObservation : Observation<BehaviorFrequency, S
         BehaviorFrequency value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechSoundFrequencyObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new SpeechSoundFrequencyObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = speechSound
+        };
     }
 
     [SkipLocalsInit]

--- a/src/DSE.Open.Observations/SpeechSoundFrequencyObservationSet.cs
+++ b/src/DSE.Open.Observations/SpeechSoundFrequencyObservationSet.cs
@@ -1,41 +1,14 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
-public sealed record SpeechSoundFrequencyObservationSet : ObservationSet<SpeechSoundFrequencyObservation, BehaviorFrequency>
+public sealed record
+    SpeechSoundFrequencyObservationSet : ObservationSet<SpeechSoundFrequencyObservation, BehaviorFrequency>
 {
-    internal SpeechSoundFrequencyObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechSoundFrequencyObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SpeechSoundFrequencyObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpeechSoundFrequencyObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SpeechSoundFrequencyObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +42,14 @@ public sealed record SpeechSoundFrequencyObservationSet : ObservationSet<SpeechS
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpeechSoundFrequencyObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SpeechSoundFrequencyObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundFrequencySnapshot.cs
+++ b/src/DSE.Open.Observations/SpeechSoundFrequencySnapshot.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Speech;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpeechSoundFrequencySnapshot : Snapshot<SpeechSoundFrequencyObservation, BehaviorFrequency, SpeechSound>
 {
-    [JsonConstructor]
-    internal SpeechSoundFrequencySnapshot(DateTimeOffset time, SpeechSoundFrequencyObservation observation) : base(time, observation)
-    {
-    }
-
     public static SpeechSoundFrequencySnapshot ForUtcNow(SpeechSoundFrequencyObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record SpeechSoundFrequencySnapshot : Snapshot<SpeechSoundFrequenc
 
     public static SpeechSoundFrequencySnapshot ForUtcNow(SpeechSoundFrequencyObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SpeechSoundFrequencySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SpeechSoundFrequencySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpeechSoundFrequencySnapshotSet.cs
+++ b/src/DSE.Open.Observations/SpeechSoundFrequencySnapshotSet.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Speech;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record SpeechSoundFrequencySnapshotSet
     : SnapshotSet<SpeechSoundFrequencySnapshot, SpeechSoundFrequencyObservation, BehaviorFrequency, SpeechSound>
 {
-    protected SpeechSoundFrequencySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundFrequencySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SpeechSoundFrequencySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundFrequencySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpeechSoundFrequencySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpeechSoundFrequencySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SpeechSoundFrequencySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SpeechSoundFrequencySnapshot> snapshots)
@@ -61,6 +27,12 @@ public record SpeechSoundFrequencySnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SpeechSoundFrequencySnapshotSet(now, now, trackerReference, snapshots);
+        return new SpeechSoundFrequencySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpokenWordClarityMeasure.cs
+++ b/src/DSE.Open.Observations/SpokenWordClarityMeasure.cs
@@ -1,29 +1,25 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpokenWordClarityMeasure : Measure<SpokenWordClarityObservation, SpeechClarity, WordId>
 {
+    [SetsRequiredMembers]
     public SpokenWordClarityMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal SpokenWordClarityMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
+    public override SpokenWordClarityObservation CreateObservation(WordId wordId, SpeechClarity value, DateTimeOffset timestamp)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override SpokenWordClarityObservation CreateObservation(WordId speechSound, SpeechClarity value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
-    {
-        return SpokenWordClarityObservation.Create(this, speechSound, value, TimeProvider.System);
+        return SpokenWordClarityObservation.Create(this, wordId, value, TimeProvider.System);
     }
 }

--- a/src/DSE.Open.Observations/SpokenWordClarityObservation.cs
+++ b/src/DSE.Open.Observations/SpokenWordClarityObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -11,36 +10,30 @@ namespace DSE.Open.Observations;
 
 public record SpokenWordClarityObservation : Observation<SpeechClarity, WordId>
 {
-    protected SpokenWordClarityObservation(Measure measure, WordId discriminator, DateTimeOffset time, SpeechClarity value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpokenWordClarityObservation(ObservationId id, MeasureId measureId, WordId discriminator, long timestamp, SpeechClarity value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public WordId WordId => Discriminator;
 
-    public static SpokenWordClarityObservation Create(Measure measure, WordId speechSound, SpeechClarity value)
+    public static SpokenWordClarityObservation Create(Measure measure, WordId wordId, SpeechClarity value)
     {
-        return Create(measure, speechSound, value, TimeProvider.System);
+        return Create(measure, wordId, value, TimeProvider.System);
     }
 
     public static SpokenWordClarityObservation Create(
         Measure measure,
-        WordId speechSound,
+        WordId wordId,
         SpeechClarity value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpokenWordClarityObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new SpokenWordClarityObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = wordId
+        };
     }
 
     protected override ulong GetDiscriminatorId()

--- a/src/DSE.Open.Observations/SpokenWordClarityObservationSet.cs
+++ b/src/DSE.Open.Observations/SpokenWordClarityObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record SpokenWordClarityObservationSet : ObservationSet<SpokenWordClarityObservation, SpeechClarity>
 {
-    internal SpokenWordClarityObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpokenWordClarityObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal SpokenWordClarityObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<SpokenWordClarityObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static SpokenWordClarityObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record SpokenWordClarityObservationSet : ObservationSet<SpokenWord
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new SpokenWordClarityObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new SpokenWordClarityObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpokenWordClaritySnapshot.cs
+++ b/src/DSE.Open.Observations/SpokenWordClaritySnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record SpokenWordClaritySnapshot : Snapshot<SpokenWordClarityObservation, SpeechClarity, WordId>
 {
-    [JsonConstructor]
-    internal SpokenWordClaritySnapshot(DateTimeOffset time, SpokenWordClarityObservation observation) : base(time, observation)
-    {
-    }
-
     public static SpokenWordClaritySnapshot ForUtcNow(SpokenWordClarityObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -20,7 +14,13 @@ public sealed record SpokenWordClaritySnapshot : Snapshot<SpokenWordClarityObser
 
     public static SpokenWordClaritySnapshot ForUtcNow(SpokenWordClarityObservation observation, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(observation);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new SpokenWordClaritySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new SpokenWordClaritySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/SpokenWordClaritySnapshotSet.cs
+++ b/src/DSE.Open.Observations/SpokenWordClaritySnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record SpokenWordClaritySnapshotSet
     : SnapshotSet<SpokenWordClaritySnapshot, SpokenWordClarityObservation, SpeechClarity, WordId>
 {
-    protected SpokenWordClaritySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpokenWordClaritySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected SpokenWordClaritySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpokenWordClaritySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected SpokenWordClaritySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<SpokenWordClaritySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static SpokenWordClaritySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<SpokenWordClaritySnapshot> snapshots)
@@ -61,6 +27,13 @@ public record SpokenWordClaritySnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new SpokenWordClaritySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new SpokenWordClaritySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/WordFrequencyMeasure.cs
+++ b/src/DSE.Open.Observations/WordFrequencyMeasure.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
@@ -11,22 +11,21 @@ namespace DSE.Open.Observations;
 /// </summary>
 public sealed record WordFrequencyMeasure : Measure<WordFrequencyObservation, BehaviorFrequency, WordId>
 {
+    [SetsRequiredMembers]
     public WordFrequencyMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
-    [JsonConstructor]
-    internal WordFrequencyMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
+    public override WordFrequencyObservation CreateObservation(
+        WordId wordId,
+        BehaviorFrequency value,
+        DateTimeOffset timestamp)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(measurementLevel, MeasurementLevel.Binary);
-    }
-
-#pragma warning disable CA1725 // Parameter names should match base declaration
-    public override WordFrequencyObservation CreateObservation(WordId speechSound, BehaviorFrequency value, DateTimeOffset timestamp)
-#pragma warning restore CA1725 // Parameter names should match base declaration
-    {
-        return WordFrequencyObservation.Create(this, speechSound, value, TimeProvider.System);
+        return WordFrequencyObservation.Create(this, wordId, value, TimeProvider.System);
     }
 }

--- a/src/DSE.Open.Observations/WordFrequencyObservation.cs
+++ b/src/DSE.Open.Observations/WordFrequencyObservation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -15,36 +14,30 @@ namespace DSE.Open.Observations;
 /// </summary>
 public record WordFrequencyObservation : Observation<BehaviorFrequency, WordId>
 {
-    protected WordFrequencyObservation(Measure measure, WordId discriminator, DateTimeOffset time, BehaviorFrequency value)
-        : base(measure, discriminator, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected WordFrequencyObservation(ObservationId id, MeasureId measureId, WordId discriminator, long timestamp, BehaviorFrequency value)
-        : base(id, measureId, discriminator, timestamp, value)
-    {
-    }
-
     [JsonIgnore]
     public WordId WordId => Discriminator;
 
-    public static WordFrequencyObservation Create(Measure measure, WordId speechSound, BehaviorFrequency value)
+    public static WordFrequencyObservation Create(Measure measure, WordId wordId, BehaviorFrequency value)
     {
-        return Create(measure, speechSound, value, TimeProvider.System);
+        return Create(measure, wordId, value, TimeProvider.System);
     }
 
     public static WordFrequencyObservation Create(
         Measure measure,
-        WordId speechSound,
+        WordId wordId,
         BehaviorFrequency value,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(measure);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new WordFrequencyObservation(measure, speechSound, timeProvider.GetUtcNow(), value);
+        return new WordFrequencyObservation
+        {
+            Time = timeProvider.GetUtcNow(),
+            MeasureId = measure.Id,
+            Value = value,
+            Discriminator = wordId
+        };
     }
 
     [SkipLocalsInit]

--- a/src/DSE.Open.Observations/WordFrequencyObservationSet.cs
+++ b/src/DSE.Open.Observations/WordFrequencyObservationSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Values;
 
@@ -10,32 +8,6 @@ namespace DSE.Open.Observations;
 
 public sealed record WordFrequencyObservationSet : ObservationSet<WordFrequencyObservation, BehaviorFrequency>
 {
-    internal WordFrequencyObservationSet(
-        DateTimeOffset created,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<WordFrequencyObservation> observations)
-        : base(created, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal WordFrequencyObservationSet(
-        ObservationSetId id,
-        long createdTimestamp,
-        Identifier trackerReference,
-        Identifier observerReference,
-        Uri source,
-        GroundPoint? location,
-        ReadOnlyValueCollection<WordFrequencyObservation> observations)
-        : base(id, createdTimestamp, trackerReference, observerReference, source, location, observations)
-    {
-    }
-
     public static WordFrequencyObservationSet Create(
         Identifier trackerReference,
         Identifier observerReference,
@@ -69,6 +41,14 @@ public sealed record WordFrequencyObservationSet : ObservationSet<WordFrequencyO
         ArgumentNullException.ThrowIfNull(observations);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        return new WordFrequencyObservationSet(timeProvider.GetUtcNow(), trackerReference, observerReference, source, location, observations);
+        return new WordFrequencyObservationSet
+        {
+            Created = timeProvider.GetUtcNow(),
+            TrackerReference = trackerReference,
+            ObserverReference = observerReference,
+            Source = source,
+            Location = location,
+            Observations = observations
+        };
     }
 }

--- a/src/DSE.Open.Observations/WordFrequencySnapshot.cs
+++ b/src/DSE.Open.Observations/WordFrequencySnapshot.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Text.Json.Serialization;
 using DSE.Open.Language;
 
 namespace DSE.Open.Observations;
 
 public sealed record WordFrequencySnapshot : Snapshot<WordFrequencyObservation, BehaviorFrequency, WordId>
 {
-    [JsonConstructor]
-    internal WordFrequencySnapshot(DateTimeOffset time, WordFrequencyObservation observation) : base(time, observation)
-    {
-    }
-
     public static WordFrequencySnapshot ForUtcNow(WordFrequencyObservation observation)
     {
         return ForUtcNow(observation, TimeProvider.System);
@@ -21,6 +15,11 @@ public sealed record WordFrequencySnapshot : Snapshot<WordFrequencyObservation, 
     public static WordFrequencySnapshot ForUtcNow(WordFrequencyObservation observation, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
-        return new WordFrequencySnapshot(timeProvider.GetUtcNow(), observation);
+
+        return new WordFrequencySnapshot
+        {
+            Time = timeProvider.GetUtcNow(),
+            Observation = observation
+        };
     }
 }

--- a/src/DSE.Open.Observations/WordFrequencySnapshotSet.cs
+++ b/src/DSE.Open.Observations/WordFrequencySnapshotSet.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Text.Json.Serialization;
 using DSE.Open.Collections.Generic;
 using DSE.Open.Language;
 using DSE.Open.Values;
@@ -12,38 +10,6 @@ namespace DSE.Open.Observations;
 public record WordFrequencySnapshotSet
     : SnapshotSet<WordFrequencySnapshot, WordFrequencyObservation, BehaviorFrequency, WordId>
 {
-    protected WordFrequencySnapshotSet(
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<WordFrequencySnapshot> snapshots)
-        : base(created, updated, trackerReference, snapshots)
-    {
-    }
-
-    protected WordFrequencySnapshotSet(
-        Identifier id,
-        DateTimeOffset created,
-        DateTimeOffset updated,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<WordFrequencySnapshot> snapshots)
-        : base(id, created, updated, trackerReference, snapshots)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    protected WordFrequencySnapshotSet(
-        Identifier id,
-        long createdTimestamp,
-        long updatedTimestamp,
-        Identifier trackerReference,
-        ReadOnlyValueCollection<WordFrequencySnapshot> snapshots)
-        : base(id, createdTimestamp, updatedTimestamp, trackerReference, snapshots)
-    {
-    }
-
     public static WordFrequencySnapshotSet Create(
         Identifier trackerReference,
         ReadOnlyValueCollection<WordFrequencySnapshot> snapshots)
@@ -61,6 +27,13 @@ public record WordFrequencySnapshotSet
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         var now = timeProvider.GetUtcNow();
-        return new WordFrequencySnapshotSet(now, now, trackerReference, snapshots);
+
+        return new WordFrequencySnapshotSet
+        {
+            Created = now,
+            Updated = now,
+            TrackerReference = trackerReference,
+            Snapshots = snapshots
+        };
     }
 }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.AmountMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => AmountMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = AmountMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = AmountMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.AmountObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (long)args[2], (global::DSE.Open.Values.Amount)args[3]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountObservation(){ Value = (global::DSE.Open.Values.Amount)args[0], Id = (global::DSE.Open.Observations.ObservationId)args[1], Time = (global::System.DateTimeOffset)args[2], MeasureId = (global::DSE.Open.Observations.MeasureId)args[3] },
                     PropertyMetadataInitializer = _ => AmountObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = AmountObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(long), typeof(global::DSE.Open.Values.Amount)}, modifiers: null),
-                    SerializeHandler = AmountObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.AmountObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] AmountObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[6];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Amount>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Amount>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Amount>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Amount>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = -1;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -77,7 +78,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -96,42 +97,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -89800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -89800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -139,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -149,10 +131,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info4);
-            properties[4].Order = -88000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -88000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -170,10 +153,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info5);
-            properties[5].IsGetNullable = false;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info4);
+            properties[4].IsGetNullable = false;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -191,74 +174,43 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info6);
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info5);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void AmountObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.AmountObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_v);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Amount>)value).Value, Amount);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] AmountObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(global::DSE.Open.Values.Amount),
+                Position = 0,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.AmountObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => AmountObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = AmountObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>)}, modifiers: null),
-                    SerializeHandler = AmountObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.AmountObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] AmountObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.AmountObservation, global::DSE.Open.Values.Amount>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.AmountObservation, global::DSE.Open.Values.Amount>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'AmountObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void AmountObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.AmountObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionAmountObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.AmountObservation, global::DSE.Open.Values.Amount>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] AmountObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.AmountObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountSnapshot.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.AmountSnapshot.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.AmountSnapshot>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountSnapshot((global::System.DateTimeOffset)args[0], (global::DSE.Open.Observations.AmountObservation)args[1]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.AmountSnapshot(){ Observation = (global::DSE.Open.Observations.AmountObservation)args[0], Time = (global::System.DateTimeOffset)args[1] },
                     PropertyMetadataInitializer = _ => AmountSnapshotPropInit(options),
                     ConstructorParameterMetadataInitializer = AmountSnapshotCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountSnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::System.DateTimeOffset), typeof(global::DSE.Open.Observations.AmountObservation)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.AmountSnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
                     SerializeHandler = null,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.AmountObservation>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.AmountObservation>)obj).Observation,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.AmountObservation>(options, info0);
+            properties[0].IsRequired = true;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.DateTimeOffset>
             {
@@ -76,7 +77,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot),
                 Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot)obj).Time,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +88,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info1);
+            properties[1].IsRequired = true;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -136,22 +138,18 @@ namespace DSE.Open.Observations
         {
             new()
             {
-                Name = "time",
-                ParameterType = typeof(global::System.DateTimeOffset),
+                Name = "Observation",
+                ParameterType = typeof(global::DSE.Open.Observations.AmountObservation),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observation",
-                ParameterType = typeof(global::DSE.Open.Observations.AmountObservation),
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BehaviorFrequencyMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BehaviorFrequencyMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BehaviorFrequencyMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BehaviorFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BehaviorFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => BehaviorFrequencyMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = BehaviorFrequencyMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BehaviorFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BehaviorFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = BehaviorFrequencyMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => BinaryMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = BinaryMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (long)args[2], (bool)args[3]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryObservation(){ Value = (bool)args[0], Id = (global::DSE.Open.Observations.ObservationId)args[1], Time = (global::System.DateTimeOffset)args[2], MeasureId = (global::DSE.Open.Observations.MeasureId)args[3] },
                     PropertyMetadataInitializer = _ => BinaryObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(long), typeof(bool)}, modifiers: null),
-                    SerializeHandler = BinaryObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinaryObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinaryObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[6];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = -1;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -77,7 +78,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -96,42 +97,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -89800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -89800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -139,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -149,10 +131,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info4);
-            properties[4].Order = -88000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -88000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -170,10 +153,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info5);
-            properties[5].IsGetNullable = false;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info4);
+            properties[4].IsGetNullable = false;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -191,73 +174,43 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info6);
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info5);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinaryObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinaryObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WriteBoolean(PropName_v, ((global::DSE.Open.Observations.Observation<bool>)value).Value);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinaryObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(bool),
+                Position = 0,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => BinaryObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>)}, modifiers: null),
-                    SerializeHandler = BinaryObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinaryObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinaryObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryObservation, bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryObservation, bool>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinaryObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinaryObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionBinaryObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryObservation, bool>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinaryObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySentenceMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => BinarySentenceMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySentenceMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = BinarySentenceMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySentenceObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (global::DSE.Open.Language.SentenceId)args[2], (long)args[3], (bool)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceObservation(){ Discriminator = (global::DSE.Open.Language.SentenceId)args[0], Value = (bool)args[1], Id = (global::DSE.Open.Observations.ObservationId)args[2], Time = (global::System.DateTimeOffset)args[3], MeasureId = (global::DSE.Open.Observations.MeasureId)args[4] },
                     PropertyMetadataInitializer = _ => BinarySentenceObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySentenceObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(global::DSE.Open.Language.SentenceId), typeof(long), typeof(bool)}, modifiers: null),
-                    SerializeHandler = BinarySentenceObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinarySentenceObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinarySentenceObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[9];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Language.SentenceId>
             {
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.SentenceId>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.SentenceId>)obj).Discriminator,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +87,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Language.SentenceId>(options, info1);
+            properties[1].IsRequired = true;
             properties[1].Order = -100;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -108,6 +109,7 @@ namespace DSE.Open.Observations
             };
             
             properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info2);
+            properties[2].IsRequired = true;
             properties[2].Order = -1;
 
             var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -118,7 +120,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -137,42 +139,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
-
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info5);
-            properties[5].Order = -89800;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89800;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -180,7 +163,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -190,10 +173,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info6);
-            properties[6].Order = -88000;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -88000;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -211,10 +195,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info7);
-            properties[7].IsGetNullable = false;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info6);
+            properties[6].IsGetNullable = false;
 
-            var info8 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -232,85 +216,51 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[8] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info8);
+            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info7);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinarySentenceObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinarySentenceObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_d);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.SentenceId>)value).Discriminator, SentenceId);
-            writer.WriteBoolean(PropName_v, ((global::DSE.Open.Observations.Observation<bool>)value).Value);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinarySentenceObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "discriminator",
+                Name = "Discriminator",
                 ParameterType = typeof(global::DSE.Open.Language.SentenceId),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                Position = 0,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(bool),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 3,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySentenceObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySentenceObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySentenceObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => BinarySentenceObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySentenceObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>)}, modifiers: null),
-                    SerializeHandler = BinarySentenceObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySentenceObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinarySentenceObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinarySentenceObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySentenceObservation, bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySentenceObservation, bool>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySentenceObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinarySentenceObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinarySentenceObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionBinarySentenceObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySentenceObservation, bool>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinarySentenceObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySentenceObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySnapshot.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySnapshot.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySnapshot>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySnapshot((global::System.DateTimeOffset)args[0], (global::DSE.Open.Observations.BinaryObservation)args[1]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySnapshot(){ Observation = (global::DSE.Open.Observations.BinaryObservation)args[0], Time = (global::System.DateTimeOffset)args[1] },
                     PropertyMetadataInitializer = _ => BinarySnapshotPropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySnapshotCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::System.DateTimeOffset), typeof(global::DSE.Open.Observations.BinaryObservation)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
                     SerializeHandler = null,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.BinaryObservation>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.BinaryObservation>)obj).Observation,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.BinaryObservation>(options, info0);
+            properties[0].IsRequired = true;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.DateTimeOffset>
             {
@@ -76,7 +77,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot),
                 Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot)obj).Time,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +88,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info1);
+            properties[1].IsRequired = true;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -136,22 +138,18 @@ namespace DSE.Open.Observations
         {
             new()
             {
-                Name = "time",
-                ParameterType = typeof(global::System.DateTimeOffset),
+                Name = "Observation",
+                ParameterType = typeof(global::DSE.Open.Observations.BinaryObservation),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observation",
-                ParameterType = typeof(global::DSE.Open.Observations.BinaryObservation),
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySpeechSoundMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => BinarySpeechSoundMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySpeechSoundMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = BinarySpeechSoundMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySpeechSoundObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (global::DSE.Open.Speech.SpeechSound)args[2], (long)args[3], (bool)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundObservation(){ Discriminator = (global::DSE.Open.Speech.SpeechSound)args[0], Value = (bool)args[1], Id = (global::DSE.Open.Observations.ObservationId)args[2], Time = (global::System.DateTimeOffset)args[3], MeasureId = (global::DSE.Open.Observations.MeasureId)args[4] },
                     PropertyMetadataInitializer = _ => BinarySpeechSoundObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySpeechSoundObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(global::DSE.Open.Speech.SpeechSound), typeof(long), typeof(bool)}, modifiers: null),
-                    SerializeHandler = BinarySpeechSoundObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinarySpeechSoundObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinarySpeechSoundObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[9];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Speech.SpeechSound>
             {
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Speech.SpeechSound>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Speech.SpeechSound>)obj).Discriminator,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +87,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Speech.SpeechSound>(options, info1);
+            properties[1].IsRequired = true;
             properties[1].Order = -100;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -108,6 +109,7 @@ namespace DSE.Open.Observations
             };
             
             properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info2);
+            properties[2].IsRequired = true;
             properties[2].Order = -1;
 
             var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -118,7 +120,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -137,42 +139,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
-
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info5);
-            properties[5].Order = -89800;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89800;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -180,7 +163,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -190,10 +173,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info6);
-            properties[6].Order = -88000;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -88000;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -211,10 +195,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info7);
-            properties[7].IsGetNullable = false;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info6);
+            properties[6].IsGetNullable = false;
 
-            var info8 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -232,85 +216,51 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[8] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info8);
+            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info7);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinarySpeechSoundObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinarySpeechSoundObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_d);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Speech.SpeechSound>)value).Discriminator, SpeechSound);
-            writer.WriteBoolean(PropName_v, ((global::DSE.Open.Observations.Observation<bool>)value).Value);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinarySpeechSoundObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "discriminator",
+                Name = "Discriminator",
                 ParameterType = typeof(global::DSE.Open.Speech.SpeechSound),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                Position = 0,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(bool),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 3,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinarySpeechSoundObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinarySpeechSoundObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinarySpeechSoundObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => BinarySpeechSoundObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = BinarySpeechSoundObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>)}, modifiers: null),
-                    SerializeHandler = BinarySpeechSoundObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinarySpeechSoundObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinarySpeechSoundObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinarySpeechSoundObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySpeechSoundObservation, bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySpeechSoundObservation, bool>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinarySpeechSoundObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinarySpeechSoundObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinarySpeechSoundObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionBinarySpeechSoundObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinarySpeechSoundObservation, bool>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinarySpeechSoundObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinarySpeechSoundObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryWordMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => BinaryWordMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryWordMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = BinaryWordMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryWordObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (global::DSE.Open.Language.WordId)args[2], (long)args[3], (bool)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordObservation(){ Discriminator = (global::DSE.Open.Language.WordId)args[0], Value = (bool)args[1], Id = (global::DSE.Open.Observations.ObservationId)args[2], Time = (global::System.DateTimeOffset)args[3], MeasureId = (global::DSE.Open.Observations.MeasureId)args[4] },
                     PropertyMetadataInitializer = _ => BinaryWordObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryWordObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(global::DSE.Open.Language.WordId), typeof(long), typeof(bool)}, modifiers: null),
-                    SerializeHandler = BinaryWordObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinaryWordObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinaryWordObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[9];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Language.WordId>
             {
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.WordId>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.WordId>)obj).Discriminator,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +87,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Language.WordId>(options, info1);
+            properties[1].IsRequired = true;
             properties[1].Order = -100;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<bool>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -108,6 +109,7 @@ namespace DSE.Open.Observations
             };
             
             properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info2);
+            properties[2].IsRequired = true;
             properties[2].Order = -1;
 
             var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -118,7 +120,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -137,42 +139,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
-
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info5);
-            properties[5].Order = -89800;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89800;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -180,7 +163,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -190,10 +173,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info6);
-            properties[6].Order = -88000;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -88000;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -211,10 +195,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info7);
-            properties[7].IsGetNullable = false;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info6);
+            properties[6].IsGetNullable = false;
 
-            var info8 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -232,85 +216,51 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[8] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info8);
+            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info7);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinaryWordObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinaryWordObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_d);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<bool, global::DSE.Open.Language.WordId>)value).Discriminator, WordId);
-            writer.WriteBoolean(PropName_v, ((global::DSE.Open.Observations.Observation<bool>)value).Value);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinaryWordObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "discriminator",
+                Name = "Discriminator",
                 ParameterType = typeof(global::DSE.Open.Language.WordId),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                Position = 0,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(bool),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 3,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.BinaryWordObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.BinaryWordObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.BinaryWordObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => BinaryWordObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = BinaryWordObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>)}, modifiers: null),
-                    SerializeHandler = BinaryWordObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.BinaryWordObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.BinaryWordObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] BinaryWordObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryWordObservation, bool>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryWordObservation, bool>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'BinaryWordObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void BinaryWordObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.BinaryWordObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionBinaryWordObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.BinaryWordObservation, bool>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] BinaryWordObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.BinaryWordObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CompletenessMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CompletenessMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.CompletenessMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CompletenessMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CompletenessMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => CompletenessMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = CompletenessMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CompletenessMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CompletenessMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = CompletenessMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.CountMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => CountMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = CountMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = CountMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.CountObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (long)args[2], (global::DSE.Open.Values.Count)args[3]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountObservation(){ Value = (global::DSE.Open.Values.Count)args[0], Id = (global::DSE.Open.Observations.ObservationId)args[1], Time = (global::System.DateTimeOffset)args[2], MeasureId = (global::DSE.Open.Observations.MeasureId)args[3] },
                     PropertyMetadataInitializer = _ => CountObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = CountObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(long), typeof(global::DSE.Open.Values.Count)}, modifiers: null),
-                    SerializeHandler = CountObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.CountObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] CountObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[6];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Count>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Count>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Count>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Count>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = -1;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -77,7 +78,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -96,42 +97,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -89800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -89800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -139,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -149,10 +131,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info4);
-            properties[4].Order = -88000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -88000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -170,10 +153,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info5);
-            properties[5].IsGetNullable = false;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info4);
+            properties[4].IsGetNullable = false;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -191,74 +174,43 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info6);
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info5);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void CountObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.CountObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_v);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Count>)value).Value, Count);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] CountObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(global::DSE.Open.Values.Count),
+                Position = 0,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.CountObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => CountObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = CountObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>)}, modifiers: null),
-                    SerializeHandler = CountObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.CountObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] CountObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.CountObservation, global::DSE.Open.Values.Count>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.CountObservation, global::DSE.Open.Values.Count>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'CountObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void CountObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.CountObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionCountObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.CountObservation, global::DSE.Open.Values.Count>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] CountObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.CountObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountSnapshot.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.CountSnapshot.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.CountSnapshot>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountSnapshot((global::System.DateTimeOffset)args[0], (global::DSE.Open.Observations.CountObservation)args[1]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.CountSnapshot(){ Observation = (global::DSE.Open.Observations.CountObservation)args[0], Time = (global::System.DateTimeOffset)args[1] },
                     PropertyMetadataInitializer = _ => CountSnapshotPropInit(options),
                     ConstructorParameterMetadataInitializer = CountSnapshotCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountSnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::System.DateTimeOffset), typeof(global::DSE.Open.Observations.CountObservation)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.CountSnapshot).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
                     SerializeHandler = null,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.CountObservation>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot<global::DSE.Open.Observations.CountObservation>)obj).Observation,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.CountObservation>(options, info0);
+            properties[0].IsRequired = true;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.DateTimeOffset>
             {
@@ -76,7 +77,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Snapshot),
                 Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
                 Getter = static obj => ((global::DSE.Open.Observations.Snapshot)obj).Time,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,6 +88,7 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info1);
+            properties[1].IsRequired = true;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -136,22 +138,18 @@ namespace DSE.Open.Observations
         {
             new()
             {
-                Name = "time",
-                ParameterType = typeof(global::System.DateTimeOffset),
+                Name = "Observation",
+                ParameterType = typeof(global::DSE.Open.Observations.CountObservation),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observation",
-                ParameterType = typeof(global::DSE.Open.Observations.CountObservation),
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.GetJsonTypeInfo.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.GetJsonTypeInfo.g.cs
@@ -267,10 +267,6 @@ namespace DSE.Open.Observations
             {
                 return Create_Uri(options);
             }
-            if (type == typeof(long))
-            {
-                return Create_Int64(options);
-            }
             if (type == typeof(string))
             {
                 return Create_String(options);

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ObservationSet.g.cs
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] ObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[6];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -75,42 +75,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info1);
-
-            var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info2);
-            properties[2].Order = -97800;
+            properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info1);
+            properties[1].IsRequired = true;
+            properties[1].Order = -97800;
 
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -118,7 +99,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -128,10 +109,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
-            properties[3].Order = -90000;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -90000;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -139,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -149,10 +131,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -89000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -89000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -160,7 +143,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -170,11 +153,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
-            properties[5].Order = -60000;
-            properties[5].IsGetNullable = false;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -60000;
+            properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,8 +167,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'ObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -192,8 +177,9 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
-            properties[6].Order = -50000;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -50000;
 
             return properties;
         }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.PropertyNames.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.PropertyNames.g.cs
@@ -15,17 +15,6 @@ namespace DSE.Open.Observations
         private static readonly global::System.Text.Json.JsonEncodedText PropName_level = global::System.Text.Json.JsonEncodedText.Encode("level");
         private static readonly global::System.Text.Json.JsonEncodedText PropName_name = global::System.Text.Json.JsonEncodedText.Encode("name");
         private static readonly global::System.Text.Json.JsonEncodedText PropName_statement = global::System.Text.Json.JsonEncodedText.Encode("statement");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_i = global::System.Text.Json.JsonEncodedText.Encode("i");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_t = global::System.Text.Json.JsonEncodedText.Encode("t");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_m = global::System.Text.Json.JsonEncodedText.Encode("m");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_v = global::System.Text.Json.JsonEncodedText.Encode("v");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_crt = global::System.Text.Json.JsonEncodedText.Encode("crt");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_trk = global::System.Text.Json.JsonEncodedText.Encode("trk");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_obr = global::System.Text.Json.JsonEncodedText.Encode("obr");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_src = global::System.Text.Json.JsonEncodedText.Encode("src");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_loc = global::System.Text.Json.JsonEncodedText.Encode("loc");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_obs = global::System.Text.Json.JsonEncodedText.Encode("obs");
-        private static readonly global::System.Text.Json.JsonEncodedText PropName_d = global::System.Text.Json.JsonEncodedText.Encode("d");
         private static readonly global::System.Text.Json.JsonEncodedText PropName_latitude = global::System.Text.Json.JsonEncodedText.Encode("latitude");
         private static readonly global::System.Text.Json.JsonEncodedText PropName_longitude = global::System.Text.Json.JsonEncodedText.Encode("longitude");
         private static readonly global::System.Text.Json.JsonEncodedText PropName_accuracy = global::System.Text.Json.JsonEncodedText.Encode("accuracy");

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.RatioMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioMeasure(){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[2], Name = (string)args[3], Statement = (string)args[4] },
                     PropertyMetadataInitializer = _ => RatioMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = RatioMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
                     SerializeHandler = RatioMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info0);
+            properties[0].IsRequired = true;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
@@ -76,7 +77,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -87,7 +88,9 @@ namespace DSE.Open.Observations
             };
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
+            properties[1].IsRequired = true;
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +100,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -108,6 +111,7 @@ namespace DSE.Open.Observations
             };
             
             properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasurementLevel>(options, info2);
+            properties[2].IsRequired = true;
 
             var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -117,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -128,7 +132,9 @@ namespace DSE.Open.Observations
             };
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
+            properties[3].IsRequired = true;
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +144,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -149,7 +155,9 @@ namespace DSE.Open.Observations
             };
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
+            properties[4].IsRequired = true;
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -223,52 +231,42 @@ namespace DSE.Open.Observations
         {
             new()
             {
-                Name = "id",
+                Name = "Id",
                 ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "uri",
+                Name = "Uri",
                 ParameterType = typeof(global::System.Uri),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "measurementLevel",
+                Name = "MeasurementLevel",
                 ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "name",
+                Name = "Name",
                 ParameterType = typeof(string),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "statement",
+                Name = "Statement",
                 ParameterType = typeof(string),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioObservation.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.RatioObservation>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioObservation((global::DSE.Open.Observations.ObservationId)args[0], (global::DSE.Open.Observations.MeasureId)args[1], (long)args[2], (global::DSE.Open.Values.Ratio)args[3]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioObservation(){ Value = (global::DSE.Open.Values.Ratio)args[0], Id = (global::DSE.Open.Observations.ObservationId)args[1], Time = (global::System.DateTimeOffset)args[2], MeasureId = (global::DSE.Open.Observations.MeasureId)args[3] },
                     PropertyMetadataInitializer = _ => RatioObservationPropInit(options),
                     ConstructorParameterMetadataInitializer = RatioObservationCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationId), typeof(global::DSE.Open.Observations.MeasureId), typeof(long), typeof(global::DSE.Open.Values.Ratio)}, modifiers: null),
-                    SerializeHandler = RatioObservationSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioObservation).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.RatioObservation>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] RatioObservationPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[6];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Ratio>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Ratio>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Ratio>)obj).Value,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,6 +67,7 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Ratio>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = -1;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationId>
@@ -77,7 +78,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservation.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -96,42 +97,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Time",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.Observation),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Timestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservation.Timestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).Time,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "Timestamp",
+                PropertyName = "Time",
                 JsonPropertyName = "t",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Timestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("Time", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -89800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -89800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasureId>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -139,7 +121,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Observation),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Observation)obj).MeasureId,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservation.MeasureId' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -149,10 +131,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.Observation).GetProperty("MeasureId", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.MeasureId), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info4);
-            properties[4].Order = -88000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.MeasureId>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -88000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -170,10 +153,10 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("ExtensionData", InstanceMemberBindingFlags, null, typeof(global::System.Collections.Generic.IReadOnlyDictionary<string, object>), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info5);
-            properties[5].IsGetNullable = false;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>(options, info4);
+            properties[4].IsGetNullable = false;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<bool>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -191,74 +174,43 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Serialization.DataTransfer.ImmutableDataTransferObject).GetProperty("HasExtensionData", InstanceMemberBindingFlags, null, typeof(bool), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info6);
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<bool>(options, info5);
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void RatioObservationSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.RatioObservation? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_i);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).Id, ObservationId);
-            writer.WriteNumber(PropName_t, ((global::DSE.Open.Observations.Observation)value).Timestamp);
-            writer.WritePropertyName(PropName_m);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation)value).MeasureId, MeasureId);
-            writer.WritePropertyName(PropName_v);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.Observation<global::DSE.Open.Values.Ratio>)value).Value, Ratio);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] RatioObservationCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
-                Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "measureId",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
-                Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "timestamp",
-                ParameterType = typeof(long),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
-                Name = "value",
+                Name = "Value",
                 ParameterType = typeof(global::DSE.Open.Values.Ratio),
+                Position = 0,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationId),
+                Position = 1,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "Time",
+                ParameterType = typeof(global::System.DateTimeOffset),
+                Position = 2,
+                IsMemberInitializer = true,
+            },
+
+            new()
+            {
+                Name = "MeasureId",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasureId),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioObservationSet.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.RatioObservationSet.g.cs
@@ -29,11 +29,11 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.RatioObservationSet>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioObservationSet((global::DSE.Open.Observations.ObservationSetId)args[0], (long)args[1], (global::DSE.Open.Values.Identifier)args[2], (global::DSE.Open.Values.Identifier)args[3], (global::System.Uri)args[4], (global::DSE.Open.Observations.GroundPoint?)args[5], (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>)args[6]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.RatioObservationSet(){ Observations = (global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>)args[0], Id = (global::DSE.Open.Observations.ObservationSetId)args[1], Created = (global::System.DateTimeOffset)args[2], TrackerReference = (global::DSE.Open.Values.Identifier)args[3], ObserverReference = (global::DSE.Open.Values.Identifier)args[4], Source = (global::System.Uri)args[5], Location = (global::DSE.Open.Observations.GroundPoint?)args[6] },
                     PropertyMetadataInitializer = _ => RatioObservationSetPropInit(options),
                     ConstructorParameterMetadataInitializer = RatioObservationSetCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.ObservationSetId), typeof(long), typeof(global::DSE.Open.Values.Identifier), typeof(global::DSE.Open.Values.Identifier), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.GroundPoint?), typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>)}, modifiers: null),
-                    SerializeHandler = RatioObservationSetSerializeHandler,
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.RatioObservationSet).GetConstructor(InstanceMemberBindingFlags, binder: null, global::System.Array.Empty<global::System.Type>(), modifiers: null),
+                    SerializeHandler = null,
                 };
                 
                 jsonTypeInfo = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateObjectInfo<global::DSE.Open.Observations.RatioObservationSet>(options, objectInfo);
@@ -46,7 +46,7 @@ namespace DSE.Open.Observations
 
         private static global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[] RatioObservationSetPropInit(global::System.Text.Json.JsonSerializerOptions options)
         {
-            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[8];
+            var properties = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfo[7];
 
             var info0 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>>
             {
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.RatioObservation, global::DSE.Open.Values.Ratio>),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.RatioObservation, global::DSE.Open.Values.Ratio>)obj).Observations,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -67,8 +67,10 @@ namespace DSE.Open.Observations
             };
             
             properties[0] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>>(options, info0);
+            properties[0].IsRequired = true;
             properties[0].Order = 900000;
             properties[0].IsGetNullable = false;
+            properties[0].IsSetNullable = false;
 
             var info1 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.ObservationSetId>
             {
@@ -78,7 +80,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Id,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -97,42 +99,23 @@ namespace DSE.Open.Observations
                 IsPublic = true,
                 IsVirtual = false,
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = null,
-                Setter = null,
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.Always,
-                HasJsonInclude = false,
-                IsExtensionData = false,
-                NumberHandling = null,
-                PropertyName = "Created",
-                JsonPropertyName = null,
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
-            };
-            
-            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
-
-            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<long>
-            {
-                IsProperty = true,
-                IsPublic = true,
-                IsVirtual = false,
-                DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
-                Converter = null,
-                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).CreatedTimestamp,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.CreatedTimestamp' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Converter = (global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>)ExpandConverter(typeof(global::System.DateTimeOffset), new global::DSE.Open.Text.Json.Serialization.JsonDateTimeOffsetUnixTimeMillisecondsConverter(), options),
+                Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Created,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
-                PropertyName = "CreatedTimestamp",
+                PropertyName = "Created",
                 JsonPropertyName = "crt",
-                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("CreatedTimestamp", InstanceMemberBindingFlags, null, typeof(long), global::System.Array.Empty<global::System.Type>(), null),
+                AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Created", InstanceMemberBindingFlags, null, typeof(global::System.DateTimeOffset), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<long>(options, info3);
-            properties[3].Order = -97800;
+            properties[2] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.DateTimeOffset>(options, info2);
+            properties[2].IsRequired = true;
+            properties[2].Order = -97800;
 
-            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info3 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -140,7 +123,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).TrackerReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.TrackerReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -150,10 +133,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("TrackerReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
-            properties[4].Order = -90000;
+            properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info3);
+            properties[3].IsRequired = true;
+            properties[3].Order = -90000;
 
-            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
+            var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Values.Identifier>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -161,7 +145,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).ObserverReference,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.ObserverReference' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -171,10 +155,11 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("ObserverReference", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Values.Identifier), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info5);
-            properties[5].Order = -89000;
+            properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Values.Identifier>(options, info4);
+            properties[4].IsRequired = true;
+            properties[4].Order = -89000;
 
-            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
+            var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Uri>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -182,7 +167,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Source,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.Source' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                Setter = static (obj, value) => ((global::DSE.Open.Observations.ObservationSet)obj).Source = value!,
                 IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
@@ -192,11 +177,13 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Source", InstanceMemberBindingFlags, null, typeof(global::System.Uri), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info6);
-            properties[6].Order = -60000;
-            properties[6].IsGetNullable = false;
+            properties[5] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info5);
+            properties[5].IsRequired = true;
+            properties[5].Order = -60000;
+            properties[5].IsGetNullable = false;
+            properties[5].IsSetNullable = false;
 
-            var info7 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
+            var info6 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.GroundPoint?>
             {
                 IsProperty = true,
                 IsPublic = true,
@@ -204,8 +191,8 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.ObservationSet),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.ObservationSet)obj).Location,
-                Setter = static (obj, value) => throw new global::System.InvalidOperationException("The member 'RatioObservationSet.Location' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                IgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
+                IgnoreCondition = null,
                 HasJsonInclude = true,
                 IsExtensionData = false,
                 NumberHandling = null,
@@ -214,115 +201,69 @@ namespace DSE.Open.Observations
                 AttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.ObservationSet).GetProperty("Location", InstanceMemberBindingFlags, null, typeof(global::DSE.Open.Observations.GroundPoint?), global::System.Array.Empty<global::System.Type>(), null),
             };
             
-            properties[7] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info7);
-            properties[7].Order = -50000;
+            properties[6] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::DSE.Open.Observations.GroundPoint?>(options, info6);
+            properties[6].IsRequired = true;
+            properties[6].Order = -50000;
 
             return properties;
-        }
-
-        // Intentionally not a static method because we create a delegate to it. Invoking delegates to instance
-        // methods is almost as fast as virtual calls. Static methods need to go through a shuffle thunk.
-        private void RatioObservationSetSerializeHandler(global::System.Text.Json.Utf8JsonWriter writer, global::DSE.Open.Observations.RatioObservationSet? value)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-                return;
-            }
-            
-            writer.WriteStartObject();
-
-            writer.WritePropertyName(PropName_id);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Id, ObservationSetId);
-            writer.WriteNumber(PropName_crt, ((global::DSE.Open.Observations.ObservationSet)value).CreatedTimestamp);
-            writer.WritePropertyName(PropName_trk);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).TrackerReference, Identifier);
-            writer.WritePropertyName(PropName_obr);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).ObserverReference, Identifier);
-            writer.WritePropertyName(PropName_src);
-            global::System.Text.Json.JsonSerializer.Serialize(writer, ((global::DSE.Open.Observations.ObservationSet)value).Source, Uri);
-            global::DSE.Open.Observations.GroundPoint? __value_Location = ((global::DSE.Open.Observations.ObservationSet)value).Location;
-            if (__value_Location is not null)
-            {
-                writer.WritePropertyName(PropName_loc);
-                global::System.Text.Json.JsonSerializer.Serialize(writer, __value_Location, NullableGroundPoint);
-            }
-            writer.WritePropertyName(PropName_obs);
-            ReadOnlyValueCollectionRatioObservationSerializeHandler(writer, ((global::DSE.Open.Observations.ObservationSet<global::DSE.Open.Observations.RatioObservation, global::DSE.Open.Values.Ratio>)value).Observations);
-
-            writer.WriteEndObject();
         }
 
         private static global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[] RatioObservationSetCtorParamInit() => new global::System.Text.Json.Serialization.Metadata.JsonParameterInfoValues[]
         {
             new()
             {
-                Name = "id",
-                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
+                Name = "Observations",
+                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>),
                 Position = 0,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "createdTimestamp",
-                ParameterType = typeof(long),
+                Name = "Id",
+                ParameterType = typeof(global::DSE.Open.Observations.ObservationSetId),
                 Position = 1,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "trackerReference",
-                ParameterType = typeof(global::DSE.Open.Values.Identifier),
+                Name = "Created",
+                ParameterType = typeof(global::System.DateTimeOffset),
                 Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observerReference",
+                Name = "TrackerReference",
                 ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 3,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "source",
-                ParameterType = typeof(global::System.Uri),
+                Name = "ObserverReference",
+                ParameterType = typeof(global::DSE.Open.Values.Identifier),
                 Position = 4,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "location",
-                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
+                Name = "Source",
+                ParameterType = typeof(global::System.Uri),
                 Position = 5,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = true,
+                IsMemberInitializer = true,
             },
 
             new()
             {
-                Name = "observations",
-                ParameterType = typeof(global::DSE.Open.Collections.Generic.ReadOnlyValueCollection<global::DSE.Open.Observations.RatioObservation>),
+                Name = "Location",
+                ParameterType = typeof(global::DSE.Open.Observations.GroundPoint?),
                 Position = 6,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionAmountObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionAmountObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.AmountObservation element in value)
             {
-                AmountObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, AmountObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinaryObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinaryObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.BinaryObservation element in value)
             {
-                BinaryObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, BinaryObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinarySentenceObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinarySentenceObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.BinarySentenceObservation element in value)
             {
-                BinarySentenceObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, BinarySentenceObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinarySpeechSoundObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinarySpeechSoundObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.BinarySpeechSoundObservation element in value)
             {
-                BinarySpeechSoundObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, BinarySpeechSoundObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinaryWordObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionBinaryWordObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.BinaryWordObservation element in value)
             {
-                BinaryWordObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, BinaryWordObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionCountObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionCountObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.CountObservation element in value)
             {
-                CountObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, CountObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionRatioObservation.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.ReadOnlyValueCollectionRatioObservation.g.cs
@@ -54,7 +54,7 @@ namespace DSE.Open.Observations
 
             foreach (global::DSE.Open.Observations.RatioObservation element in value)
             {
-                RatioObservationSerializeHandler(writer, element);
+                global::System.Text.Json.JsonSerializer.Serialize(writer, element, RatioObservation);
             }
 
             writer.WriteEndArray();

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SentenceCompletenessMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SentenceCompletenessMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SentenceCompletenessMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SentenceCompletenessMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SentenceCompletenessMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SentenceCompletenessMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SentenceCompletenessMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SentenceCompletenessMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SentenceCompletenessMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SentenceCompletenessMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SentenceFrequencyMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SentenceFrequencyMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SentenceFrequencyMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SentenceFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SentenceFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SentenceFrequencyMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SentenceFrequencyMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SentenceFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SentenceFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SentenceFrequencyMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechClarityMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechClarityMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SpeechClarityMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SpeechClarityMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SpeechClarityMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SpeechClarityMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechSoundClarityMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechSoundClarityMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SpeechSoundClarityMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechSoundClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechSoundClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SpeechSoundClarityMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SpeechSoundClarityMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechSoundClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechSoundClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SpeechSoundClarityMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechSoundFrequencyMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpeechSoundFrequencyMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SpeechSoundFrequencyMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechSoundFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpeechSoundFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SpeechSoundFrequencyMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SpeechSoundFrequencyMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechSoundFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpeechSoundFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SpeechSoundFrequencyMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpokenWordClarityMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.SpokenWordClarityMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.SpokenWordClarityMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpokenWordClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.SpokenWordClarityMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => SpokenWordClarityMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = SpokenWordClarityMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpokenWordClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.SpokenWordClarityMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = SpokenWordClarityMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.WordFrequencyMeasure.g.cs
+++ b/src/DSE.Open.Observations/gen/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/ObservationsJsonSerializerContext.WordFrequencyMeasure.g.cs
@@ -29,10 +29,10 @@ namespace DSE.Open.Observations
                 var objectInfo = new global::System.Text.Json.Serialization.Metadata.JsonObjectInfoValues<global::DSE.Open.Observations.WordFrequencyMeasure>
                 {
                     ObjectCreator = null,
-                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.WordFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (global::DSE.Open.Observations.MeasurementLevel)args[2], (string)args[3], (string)args[4]),
+                    ObjectWithParameterizedConstructorCreator = static args => new global::DSE.Open.Observations.WordFrequencyMeasure((global::DSE.Open.Observations.MeasureId)args[0], (global::System.Uri)args[1], (string)args[2], (string)args[3]){ Id = (global::DSE.Open.Observations.MeasureId)args[0], Uri = (global::System.Uri)args[1], MeasurementLevel = (global::DSE.Open.Observations.MeasurementLevel)args[4], Name = (string)args[2], Statement = (string)args[3] },
                     PropertyMetadataInitializer = _ => WordFrequencyMeasurePropInit(options),
                     ConstructorParameterMetadataInitializer = WordFrequencyMeasureCtorParamInit,
-                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.WordFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(global::DSE.Open.Observations.MeasurementLevel), typeof(string), typeof(string)}, modifiers: null),
+                    ConstructorAttributeProviderFactory = static () => typeof(global::DSE.Open.Observations.WordFrequencyMeasure).GetConstructor(InstanceMemberBindingFlags, binder: null, new[] {typeof(global::DSE.Open.Observations.MeasureId), typeof(global::System.Uri), typeof(string), typeof(string)}, modifiers: null),
                     SerializeHandler = WordFrequencyMeasureSerializeHandler,
                 };
                 
@@ -56,7 +56,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Id,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -76,7 +76,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Uri,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -88,6 +88,7 @@ namespace DSE.Open.Observations
             
             properties[1] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<global::System.Uri>(options, info1);
             properties[1].IsGetNullable = false;
+            properties[1].IsSetNullable = false;
 
             var info2 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::DSE.Open.Observations.MeasurementLevel>
             {
@@ -97,7 +98,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).MeasurementLevel,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -117,7 +118,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Name,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -129,6 +130,7 @@ namespace DSE.Open.Observations
             
             properties[3] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info3);
             properties[3].IsGetNullable = false;
+            properties[3].IsSetNullable = false;
 
             var info4 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<string>
             {
@@ -138,7 +140,7 @@ namespace DSE.Open.Observations
                 DeclaringType = typeof(global::DSE.Open.Observations.Measure),
                 Converter = null,
                 Getter = static obj => ((global::DSE.Open.Observations.Measure)obj).Statement,
-                Setter = null,
+                Setter = static (obj, value) => throw new global::System.InvalidOperationException("Setting init-only properties is not supported in source generation mode."),
                 IgnoreCondition = null,
                 HasJsonInclude = false,
                 IsExtensionData = false,
@@ -150,6 +152,7 @@ namespace DSE.Open.Observations
             
             properties[4] = global::System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreatePropertyInfo<string>(options, info4);
             properties[4].IsGetNullable = false;
+            properties[4].IsSetNullable = false;
 
             var info5 = new global::System.Text.Json.Serialization.Metadata.JsonPropertyInfoValues<global::System.Collections.Generic.IReadOnlyDictionary<string, object>>
             {
@@ -243,19 +246,9 @@ namespace DSE.Open.Observations
 
             new()
             {
-                Name = "measurementLevel",
-                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
-                Position = 2,
-                HasDefaultValue = false,
-                DefaultValue = null,
-                IsNullable = false,
-            },
-
-            new()
-            {
                 Name = "name",
                 ParameterType = typeof(string),
-                Position = 3,
+                Position = 2,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
@@ -265,10 +258,18 @@ namespace DSE.Open.Observations
             {
                 Name = "statement",
                 ParameterType = typeof(string),
-                Position = 4,
+                Position = 3,
                 HasDefaultValue = false,
                 DefaultValue = null,
                 IsNullable = false,
+            },
+
+            new()
+            {
+                Name = "MeasurementLevel",
+                ParameterType = typeof(global::DSE.Open.Observations.MeasurementLevel),
+                Position = 4,
+                IsMemberInitializer = true,
             },
         };
     }

--- a/src/DSE.Open.Testing.Xunit/AssertJson.cs
+++ b/src/DSE.Open.Testing.Xunit/AssertJson.cs
@@ -19,7 +19,7 @@ public static class AssertJson
     {
         var json = JsonSerializer.Serialize(value, options);
         var deserialized = JsonSerializer.Deserialize<T>(json, options);
-        Assert.Equivalent(value, deserialized);
+        Assert.Equivalent(value, deserialized, true);
     }
 
     /// <summary>
@@ -32,13 +32,13 @@ public static class AssertJson
     {
         var json = JsonSerializer.Serialize(value, typeInfo);
         var deserialized = JsonSerializer.Deserialize(json, typeInfo);
-        Assert.Equivalent(value, deserialized);
+        Assert.Equivalent(value, deserialized, true);
     }
 
     public static void Roundtrip<T>(T value, JsonSerializerContext context)
     {
         var json = JsonSerializer.Serialize(value, typeof(T), context);
         var deserialized = JsonSerializer.Deserialize(json, typeof(T), context);
-        Assert.Equivalent(value, deserialized);
+        Assert.Equivalent(value, deserialized, true);
     }
 }

--- a/test/DSE.Open.Observations.Abstractions.Tests/MeasureTests.cs
+++ b/test/DSE.Open.Observations.Abstractions.Tests/MeasureTests.cs
@@ -2,6 +2,7 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace DSE.Open.Observations;
@@ -130,35 +131,27 @@ public class MeasureTests
 
 public sealed record FakeBinaryObservation : Observation<bool>
 {
-    public FakeBinaryObservation(Measure measure, DateTimeOffset time, bool value)
-        : base(measure, time, value)
-    {
-    }
-
-    [JsonConstructor]
-    [Obsolete("For deserialization only", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    private FakeBinaryObservation(ObservationId id, MeasureId measureId, long timestamp, bool value)
-        : base(id, measureId, timestamp, value)
-    {
-    }
 }
 
 public sealed record FakeBinaryMeasure : Measure<FakeBinaryObservation, bool>
 {
+    [SetsRequiredMembers]
     public FakeBinaryMeasure(MeasureId id, Uri uri, string name, string statement)
-        : base(id, uri, MeasurementLevel.Binary, name, statement)
     {
-    }
-
-    [JsonConstructor]
-    public FakeBinaryMeasure(MeasureId id, Uri uri, MeasurementLevel measurementLevel, string name, string statement)
-        : base(id, uri, measurementLevel, name, statement)
-    {
+        Id = id;
+        Uri = uri;
+        MeasurementLevel = MeasurementLevel.Binary;
+        Name = name;
+        Statement = statement;
     }
 
     public override FakeBinaryObservation CreateObservation(bool value, DateTimeOffset timestamp)
     {
-        return new FakeBinaryObservation(this, timestamp, value);
+        return new FakeBinaryObservation
+        {
+            Time = timestamp,
+            MeasureId = Id,
+            Value = value
+        };
     }
 }

--- a/test/DSE.Open.Observations.Tests/AmountMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/AmountMeasureTests.cs
@@ -13,7 +13,7 @@ public sealed class AmountMeasureTests
     {
         var uri = new Uri("https://schema-test.dseapi.app/testing/measure");
         var measure = new AmountMeasure(MeasureId.GetRandomId(), uri, "Test measure", "[subject] does something");
-        AssertJson.Roundtrip(measure);
+        AssertJson.Roundtrip(measure, JsonContext.Default);
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public sealed class AmountMeasureTests
     {
         var uri = new Uri("https://schema-test.dseapi.app/testing/measure");
         var measure = new AmountMeasure(MeasureId.GetRandomId(), uri, "Test measure", "[subject] does something");
-        AssertJson.Roundtrip(measure, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(measure, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/BehaviourFrequencyMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/BehaviourFrequencyMeasureTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class BehaviourFrequencyMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var uri = new Uri("https://schema-test.dseapi.app/testing/measure");
+
+        var measure =
+            new BehaviorFrequencyMeasure(MeasureId.GetRandomId(), uri, "Test measure", "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/BinaryMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinaryMeasureTests.cs
@@ -20,7 +20,7 @@ public sealed class BinaryMeasureTests
     public void JsonRoundtrip_WithContext()
     {
         var measure = new BinaryMeasure(MeasureId.GetRandomId(), s_measureUri, "Test measure", "[subject] does something");
-        AssertJson.Roundtrip(measure, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(measure, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/BinaryObservationSetTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinaryObservationSetTests.cs
@@ -19,7 +19,7 @@ public sealed class BinaryObservationSetTests
     public void JsonRoundTrip_WithContext()
     {
         var obs = CreateBinaryObservationSet();
-        AssertJson.Roundtrip(obs, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(obs, JsonContext.Default);
     }
 
     private static BinaryObservationSet CreateBinaryObservationSet()

--- a/test/DSE.Open.Observations.Tests/BinaryObservationTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinaryObservationTests.cs
@@ -18,6 +18,6 @@ public sealed class BinaryObservationTests
     public void JsonRoundtrip_WithContext()
     {
         var obs = BinaryObservation.Create(TestMeasures.BinaryMeasure, true);
-        AssertJson.Roundtrip(obs, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(obs, JsonContext.Default);
     }
 }

--- a/test/DSE.Open.Observations.Tests/BinarySentenceMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinarySentenceMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class BinarySentenceMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new BinarySentenceMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/binary-sentence-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/BinarySentenceObservationTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinarySentenceObservationTests.cs
@@ -19,7 +19,7 @@ public sealed class BinarySentenceObservationTests
     public void JsonRoundtrip_WithContext()
     {
         var obs = BinarySentenceObservation.Create(TestMeasures.BinarySentenceMeasure, SentenceId.FromUInt64(420048260031uL), true);
-        AssertJson.Roundtrip(obs, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(obs, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/BinarySpeechSoundMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinarySpeechSoundMeasureTests.cs
@@ -21,7 +21,7 @@ public sealed class BinarySpeechSoundMeasureTests
     public void JsonRoundtrip_WithContext()
     {
         var measure = new BinarySpeechSoundMeasure(MeasureId.GetRandomId(), s_measureUri, "Test measure", "[subject] does something");
-        AssertJson.Roundtrip(measure, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(measure, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/BinarySpeechSoundObservationTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinarySpeechSoundObservationTests.cs
@@ -19,7 +19,7 @@ public sealed class BinarySpeechSoundObservationTests
     public void JsonRoundtrip_WithContext()
     {
         var obs = BinarySpeechSoundObservation.Create(TestMeasures.BinarySpeechSoundMeasure, SpeechSound.VoicedPostalveolarAffricate, true);
-        AssertJson.Roundtrip(obs, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(obs, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/BinaryWordMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinaryWordMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class BinaryWordMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new BinaryWordMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/binary-word-measure"),
+            "Test measure",
+            "Test measure description");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/BinaryWordObservationTests.cs
+++ b/test/DSE.Open.Observations.Tests/BinaryWordObservationTests.cs
@@ -19,7 +19,7 @@ public sealed class BinaryWordObservationTests
     public void JsonRoundtrip_WithContext()
     {
         var obs = BinaryWordObservation.Create(TestMeasures.BinaryWordMeasure, (WordId)420048260031uL, true);
-        AssertJson.Roundtrip(obs, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        AssertJson.Roundtrip(obs, JsonContext.Default);
     }
 
     [Fact]

--- a/test/DSE.Open.Observations.Tests/CompletenessMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/CompletenessMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class CompletenessMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new CompletenessMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/completeness-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/CountMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/CountMeasureTests.cs
@@ -8,26 +8,26 @@ namespace DSE.Open.Observations;
 
 public sealed class CountMeasureTests
 {
-    public static readonly Uri s_measureUri = new("https://schema-test.dseapi.app/testing/measure");
+    public static readonly Uri MeasureUri = new("https://schema-test.dseapi.app/testing/measure");
 
     [Fact]
     public void CanSerializeAndDeserialize()
     {
-        var measure = new CountMeasure(MeasureId.GetRandomId(), s_measureUri, "Test measure", "[subject] does something");
+        var measure = new CountMeasure(MeasureId.GetRandomId(), MeasureUri, "Test measure", "[subject] does something");
         AssertJson.Roundtrip(measure);
     }
 
     [Fact]
     public void JsonRoundtrip_WithContext()
     {
-        var measure = new CountMeasure(MeasureId.GetRandomId(), s_measureUri, "Test measure", "[subject] does something");
-        AssertJson.Roundtrip(measure, ObservationsJsonSerializerContext.RelaxedJsonEscaping);
+        var measure = new CountMeasure(MeasureId.GetRandomId(), MeasureUri, "Test measure", "[subject] does something");
+        AssertJson.Roundtrip(measure, JsonContext.Default);
     }
 
     [Fact]
     public void CanCreateObservation()
     {
-        var measure = new CountMeasure(MeasureId.GetRandomId(), s_measureUri, "Test measure", "[subject] does something");
+        var measure = new CountMeasure(MeasureId.GetRandomId(), MeasureUri, "Test measure", "[subject] does something");
         var obs = measure.CreateObservation((Count)42, DateTimeOffset.UtcNow);
         Assert.Equal(measure.Id, obs.MeasureId);
         Assert.Equal((Count)42, obs.Value);

--- a/test/DSE.Open.Observations.Tests/CountSnapshotTests.cs
+++ b/test/DSE.Open.Observations.Tests/CountSnapshotTests.cs
@@ -10,11 +10,12 @@ public sealed class CountSnapshotTests
     [Fact]
     public void New_WithInvalidDate_ShouldThrow()
     {
-        // Arrange
-        var date = DateTime.Parse("01/01/2024", null).AddDays(-1);
-
         // Act
-        void Act() => _ = new CountSnapshot(date, CountObservation.Create(TestMeasures.CountMeasure, Count.Zero));
+        static void Act() => _ = new CountSnapshot
+        {
+            Time = DateTime.Parse("01/01/2024", null).AddDays(-1),
+            Observation = CountObservation.Create(TestMeasures.CountMeasure, Count.Zero)
+        };
 
         // Assert
         Assert.Throws<ArgumentOutOfRangeException>(Act);

--- a/test/DSE.Open.Observations.Tests/JsonContext.cs
+++ b/test/DSE.Open.Observations.Tests/JsonContext.cs
@@ -2,21 +2,27 @@
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
-using DSE.Open.Text.Json;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
 
 [JsonSerializable(typeof(AmountMeasure))]
-[JsonSerializable(typeof(BinaryMeasure))]
 [JsonSerializable(typeof(BehaviorFrequencyMeasure))]
 [JsonSerializable(typeof(BinaryMeasure))]
 [JsonSerializable(typeof(BinarySentenceMeasure))]
 [JsonSerializable(typeof(BinarySpeechSoundMeasure))]
 [JsonSerializable(typeof(BinaryWordMeasure))]
-[JsonSerializable(typeof(CompletenessMeasure))]
+[JsonSerializable(typeof(BinaryObservationSet))]
+[JsonSerializable(typeof(BinarySpeechSoundObservation))]
+[JsonSerializable(typeof(BinaryWordObservation))]
+[JsonSerializable(typeof(BinarySentenceObservation))]
 [JsonSerializable(typeof(CountMeasure))]
+[JsonSerializable(typeof(CompletenessMeasure))]
+[JsonSerializable(typeof(MeasurementSnapshotSet<AmountSnapshot, AmountObservation, Amount>))]
+[JsonSerializable(typeof(MeasurementSnapshotSet<BinarySnapshot, BinaryObservation, bool>))]
+[JsonSerializable(typeof(MeasurementSnapshotSet<CountSnapshot, CountObservation, Count>))]
 [JsonSerializable(typeof(RatioMeasure))]
+[JsonSerializable(typeof(RatioSnapshotSet))]
 [JsonSerializable(typeof(SentenceCompletenessMeasure))]
 [JsonSerializable(typeof(SentenceFrequencyMeasure))]
 [JsonSerializable(typeof(SpeechClarityMeasure))]
@@ -24,11 +30,4 @@ namespace DSE.Open.Observations;
 [JsonSerializable(typeof(SpeechSoundFrequencyMeasure))]
 [JsonSerializable(typeof(SpokenWordClarityMeasure))]
 [JsonSerializable(typeof(WordFrequencyMeasure))]
-[JsonSerializable(typeof(MeasurementSnapshotSet<BinarySnapshot, BinaryObservation, bool>))]
-[JsonSerializable(typeof(MeasurementSnapshotSet<CountSnapshot, CountObservation, Count>))]
-[JsonSerializable(typeof(MeasurementSnapshotSet<AmountSnapshot, AmountObservation, Amount>))]
-[JsonSerializable(typeof(ObservationSet))]
-public partial class ObservationsJsonSerializerContext : JsonSerializerContext
-{
-    public static ObservationsJsonSerializerContext RelaxedJsonEscaping { get; } = new ObservationsJsonSerializerContext(JsonSharedOptions.RelaxedJsonEscaping);
-}
+public sealed partial class JsonContext : JsonSerializerContext;

--- a/test/DSE.Open.Observations.Tests/MeasurementSnapshotSetTests.cs
+++ b/test/DSE.Open.Observations.Tests/MeasurementSnapshotSetTests.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization;
 using DSE.Open.Values;
 
 namespace DSE.Open.Observations;
@@ -24,7 +23,7 @@ public sealed class MeasurementSnapshotSetTests
 
         // Act
         var deserialized = useContext
-            ? JsonRoundtripCore(set, ObservationsJsonSerializerContext.RelaxedJsonEscaping)
+            ? JsonRoundtripCore(set, JsonContext.Default)
             : JsonRoundtripCore(set);
 
         // Assert
@@ -46,7 +45,7 @@ public sealed class MeasurementSnapshotSetTests
 
         // Act
         var deserialized = useContext
-            ? JsonRoundtripCore(set, ObservationsJsonSerializerContext.RelaxedJsonEscaping)
+            ? JsonRoundtripCore(set, JsonContext.Default)
             : JsonRoundtripCore(set);
 
         // Assert
@@ -68,7 +67,7 @@ public sealed class MeasurementSnapshotSetTests
 
         // Act
         var deserialized = useContext
-            ? JsonRoundtripCore(set, ObservationsJsonSerializerContext.RelaxedJsonEscaping)
+            ? JsonRoundtripCore(set, JsonContext.Default)
             : JsonRoundtripCore(set);
 
         // Assert
@@ -76,7 +75,7 @@ public sealed class MeasurementSnapshotSetTests
         Assert.Equal(set, deserialized); // xUnit HashSet equality calls `SetEquals`
     }
 
-    private static TSet? JsonRoundtripCore<TSet>(TSet set, ObservationsJsonSerializerContext context)
+    private static TSet? JsonRoundtripCore<TSet>(TSet set, JsonSerializerContext context)
     {
         var json = JsonSerializer.Serialize(set, typeof(TSet), context);
         return (TSet?)JsonSerializer.Deserialize(json, typeof(TSet), context);

--- a/test/DSE.Open.Observations.Tests/RatioMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/RatioMeasureTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class RatioMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new RatioMeasure
+        {
+            Id = MeasureId.GetRandomId(),
+            Uri = new Uri("https://schema-test.dseapi.app/testing/ratio-measure"),
+            MeasurementLevel = MeasurementLevel.Absolute,
+            Name = "Test measure description",
+            Statement = "Test measure unit"
+        };
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/RatioSnapshotSetTests.cs
+++ b/test/DSE.Open.Observations.Tests/RatioSnapshotSetTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.Text.Json;
+using DSE.Open.Testing.Xunit;
+using DSE.Open.Values;
+
+namespace DSE.Open.Observations;
+
+public sealed class RatioSnapshotSetTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new RatioMeasure
+        {
+            Id = MeasureId.GetRandomId(),
+            Uri = new Uri("https://schema-test.dseapi.app/testing/ratio-measure"),
+            MeasurementLevel = MeasurementLevel.Absolute,
+            Name = "Test measure description",
+            Statement = "Test measure unit"
+        };
+
+        var obs = measure.CreateObservation(Ratio.FromValue(0.2m));
+
+        var set = RatioSnapshotSet.Create(Identifier.New(), [RatioSnapshot.ForUtcNow(obs)]);
+
+        AssertJson.Roundtrip(set, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SentenceCompletenessMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SentenceCompletenessMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SentenceCompletenessMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SentenceCompletenessMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/sentence-completeness-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SentenceFrequencyMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SentenceFrequencyMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SentenceFrequencyMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SentenceFrequencyMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/sentence-frequency-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SpeechClarityMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SpeechClarityMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SpeechClarityMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SpeechClarityMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/sentence-clarity-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SpeechSoundClarityMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SpeechSoundClarityMeasureTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SpeechSoundClarityMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SpeechSoundClarityMeasure(MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/speech-sound-clarity-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SpeechSoundFrequencyMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SpeechSoundFrequencyMeasureTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SpeechSoundFrequencyMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SpeechSoundFrequencyMeasure(MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/speech-sound-frequency-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/SpokenWordClarityMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/SpokenWordClarityMeasureTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class SpokenWordClarityMeasureTests
+{
+    [Fact]
+    public void JsonRoundtrip()
+    {
+        var measure = new SpokenWordClarityMeasure(MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/spoken-word-clarity-measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}

--- a/test/DSE.Open.Observations.Tests/WordFrequencyMeasureTests.cs
+++ b/test/DSE.Open.Observations.Tests/WordFrequencyMeasureTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Testing.Xunit;
+
+namespace DSE.Open.Observations;
+
+public sealed class WordFrequencyMeasureTests
+{
+    [Fact]
+    public void JsonRountrip()
+    {
+        var measure = new WordFrequencyMeasure(
+            MeasureId.GetRandomId(),
+            new Uri("https://schema-test.dseapi.app/testing/measure"),
+            "Test measure",
+            "[subject] does something");
+
+        AssertJson.Roundtrip(measure, JsonContext.Default);
+    }
+}


### PR DESCRIPTION
This PR

- Makes it possible for external assemblies to use source generated JSON serialization on observation types, without requiring us to export a JsonSerializerContext with access to internals.
- Removes the mess of JsonContructors, largely replacing with required init properties.
- Removes JsonIgnore DateTimeOffsets with linked long timestamps using the unix time JSON converter and truncating to milliseconds on init (for Assert.Equivalent to pass in tests).
- Extends tests of JsonSerialization, adding coverage all the way up to SnapshotSet.
