### PR TITLE
Check IsReadonly in AddRange and throw NotSupportedException

### DIFF
--- a/src/DSE.Open/Collections/Generic/CollectionExtensions.cs
+++ b/src/DSE.Open/Collections/Generic/CollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 
 namespace DSE.Open.Collections.Generic;
+
 public static partial class CollectionExtensions
 {
     private static readonly ThreadLocal<Random> s_random =
@@ -14,6 +15,11 @@ public static partial class CollectionExtensions
     public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T>? values)
     {
         ArgumentNullException.ThrowIfNull(collection);
+
+        if (collection.IsReadOnly)
+        {
+            ThrowHelper.ThrowNotSupportedException($"Cannot {nameof(AddRange)} to a read-only collection.");
+        }
 
         if (values is null)
         {


### PR DESCRIPTION
Otherwise this appears for types like `ReadOnlyValueCollection` and `ReadOnlyValueSet` where we are forced to explicitly implement these interfaces to support serialization and deserialization, and allows users to modify them in unsafe ways.