### PR TITLE
Add Log overload to NotificationLogger mapping Level to LogLevel

### DIFF
--- a/src/DSE.Open.Notifications/NotificationLogger.cs
+++ b/src/DSE.Open.Notifications/NotificationLogger.cs
@@ -92,6 +92,35 @@ public static partial class NotificationLogger
             notification.Message);
     }
 
+    /// <summary>
+    /// Logs the notification using the specified logger, mapping the notification level to the appropriate log level.
+    /// </summary>
+    /// <param name="logger"></param>
+    /// <param name="notification"></param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the notification level is not recognised.</exception>
+    public static void Log(ILogger logger, INotification notification)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var logLevel = notification.Level switch
+        {
+            NotificationLevel.Trace => LogLevel.Trace,
+            NotificationLevel.Debug => LogLevel.Debug,
+            NotificationLevel.Information => LogLevel.Information,
+            NotificationLevel.Warning => LogLevel.Warning,
+            NotificationLevel.Error => LogLevel.Error,
+            NotificationLevel.Critical => LogLevel.Critical,
+            _ => throw new ArgumentOutOfRangeException(nameof(notification), notification.Level, "Invalid notification level")
+        };
+
+        Log(
+            logger,
+            logLevel,
+            notification.Code,
+            notification.Message);
+    }
+
     [LoggerMessage(message: "[{diagnosticCode}] {message}")]
     public static partial void Log(ILogger logger, LogLevel level, DiagnosticCode diagnosticCode, string message);
 }


### PR DESCRIPTION
In many places we do

```cs
if (!result.HasValueAndNoErrorNotifications())
{
    foreach (var e in result.Notifications.WhereErrorOrAbove())
    {
        NotificationLogger.LogError(_logger, e);
    }
}
```

which means critical notifications are logged as errors. This allows us now to call `NotificationLogger.Log(Logger, e)` and map that to the equivalent log level. 