### PR TITLE
Override ToString on SessionContext for logging

### DIFF
--- a/src/DSE.Open.Sessions/SessionContext.cs
+++ b/src/DSE.Open.Sessions/SessionContext.cs
@@ -87,4 +87,9 @@ public sealed class SessionContext
             _storageTokens[key] = value;
         }
     }
+
+    public override string ToString()
+    {
+        return $$"""SessionContext { Id = {{Id}}, Created = {{Created}}, StorageTokens.Count =  {{_storageTokens.Count}} }""";
+    }
 }


### PR DESCRIPTION
I went with a record-like style. We _could_ make it a record (it is sealed, so that's not breaking), however we want the count of `StorageTokens` anyway so the default `ToString` wouldn't do what we want.