### PR TITLE
Rename LanguageTag.ToAsciiString to AsAsciiString

### DIFF
--- a/src/DSE.Open.Globalization/LanguageTag.cs
+++ b/src/DSE.Open.Globalization/LanguageTag.cs
@@ -177,7 +177,16 @@ public readonly partial struct LanguageTag
         return LanguagePartEquals(otherLangPart._value.AsSpan());
     }
 
+    [Obsolete($"Renamed to {nameof(AsAsciiString)}")]
     public AsciiString ToAsciiString()
+    {
+        return _value;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="AsciiString"/> representation of this <see cref="LanguageTag"/>.
+    /// </summary>
+    public AsciiString AsAsciiString()
     {
         return _value;
     }


### PR DESCRIPTION
Follows the naming pattern for conversions that return another representation without allocating.