### PR TITLE
Add Expect and Copied extensions for numerics collections

### DIFF
--- a/src/DSE.Open.Numerics/ReadOnlyCategorySetExtensions.cs
+++ b/src/DSE.Open.Numerics/ReadOnlyCategorySetExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public static class ReadOnlyCategorySetExtensions
+{
+    public static CategorySet<T> Copied<T>(this ReadOnlyCategorySet<T> categorySet)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(categorySet);
+        return new CategorySet<T>(categorySet);
+    }
+}

--- a/src/DSE.Open.Numerics/ReadOnlyDataFrameExtensions.cs
+++ b/src/DSE.Open.Numerics/ReadOnlyDataFrameExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public static class ReadOnlyDataFrameExtensions
+{
+    /// <summary>
+    /// Gets the specified typed series from the <paramref name="dataFrame"/>, if present. Otherwise, throws.
+    /// </summary>
+    /// <param name="dataFrame">The data-frame.</param>
+    /// <param name="name">The name of the series.</param>
+    /// <typeparam name="T">The expected <em>element</em> type of the series.</typeparam>
+    /// <exception cref="KeyNotFoundException">The <paramref name="dataFrame"/> does not contain a series named <paramref name="name"/>.</exception>
+    /// <exception cref="InvalidDataException">The series does not have elements of type <typeparamref name="T"/></exception>
+    public static ReadOnlySeries<T> Expect<T>(this ReadOnlyDataFrame dataFrame, string name)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(dataFrame);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var series = dataFrame[name] ?? throw new KeyNotFoundException($"The series '{name}' was not found in the data frame.");
+        return series.Expect<T>();
+    }
+}

--- a/src/DSE.Open.Numerics/ReadOnlySeriesExtensions.cs
+++ b/src/DSE.Open.Numerics/ReadOnlySeriesExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+
+namespace DSE.Open.Numerics;
+
+public static class ReadOnlySeriesExtensions
+{
+    /// <summary>
+    /// Gets the series with elements typed to the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="series">The series.</param>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <exception cref="InvalidDataException">The <paramref name="series"/> does not have elements of type <typeparamref name="T"/></exception>
+    public static ReadOnlySeries<T> Expect<T>(this ReadOnlySeries series)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(series);
+
+        if (series is not ReadOnlySeries<T> typedData)
+        {
+            throw new InvalidDataException(
+                $"Expected series to be of type {typeof(ReadOnlySeries<T>)} but was {series?.GetType()}.");
+        }
+
+        return typedData;
+    }
+
+    /// <summary>
+    /// Creates a mutable copy of the specified read-only series.
+    /// </summary>
+    /// <param name="series">The series to copy.</param>
+    public static Series<T> Copied<T>(this ReadOnlySeries<T> series)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(series);
+        return new Series<T>(series.Vector.Copied(), series.Name, series.Categories.Copied(), series.ValueLabels.Copied());
+    }
+}

--- a/src/DSE.Open.Numerics/ReadOnlyValueLabelCollectionExtensions.cs
+++ b/src/DSE.Open.Numerics/ReadOnlyValueLabelCollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public static class ReadOnlyValueLabelCollectionExtensions
+{
+    /// <summary>
+    /// Creates a mutable copy of the specified <paramref name="valueLabels"/>.
+    /// </summary>
+    /// <param name="valueLabels">The labels to copy.</param>
+    public static ValueLabelCollection<T> Copied<T>(this ReadOnlyValueLabelCollection<T> valueLabels)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(valueLabels);
+        return new ValueLabelCollection<T>(valueLabels);
+    }
+}

--- a/src/DSE.Open.Numerics/ReadOnlyVectorExtensions.cs
+++ b/src/DSE.Open.Numerics/ReadOnlyVectorExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public static class ReadOnlyVectorExtensions
+{
+    /// <summary>
+    /// Creates a mutable copy of the <paramref name="vector"/>.
+    /// </summary>
+    /// <param name="vector">The read-only vector to copy.</param>
+    public static Vector<T> Copied<T>(this ReadOnlyVector<T> vector)
+        where T : IEquatable<T>
+    {
+        ArgumentNullException.ThrowIfNull(vector);
+        return new Vector<T>(vector.ToArray());
+    }
+}

--- a/test/DSE.Open.Numerics.Tests/ReadOnlyDataFrameExtensionsTests.cs
+++ b/test/DSE.Open.Numerics.Tests/ReadOnlyDataFrameExtensionsTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public sealed class ReadOnlyDataFrameExtensionsTests
+{
+    [Fact]
+    public void Expect_WithValidSeries_ShouldReturnTypedSeries()
+    {
+        // Arrange
+        const string seriesName = "Test Series";
+        var expected = ReadOnlySeries.Create([1, 2, 3], seriesName);
+        var dataFrame = ReadOnlyDataFrame.Create([expected]);
+
+        // Act
+        var series = dataFrame.Expect<int>(seriesName);
+
+        // Assert
+        Assert.Same(expected, series);
+    }
+
+    [Fact]
+    public void Expect_WithMissingSeries_ShouldThrowKeyNotFoundException()
+    {
+        // Arrange
+        var dataFrame = ReadOnlyDataFrame.Create([]);
+
+        // Act
+        void Act() => dataFrame.Expect<int>("Missing Series");
+
+        // Assert
+        _ = Assert.Throws<KeyNotFoundException>(Act);
+    }
+
+    [Fact]
+    public void Expect_WithMismatchedType_ShouldThrowInvalidDataException()
+    {
+        // Arrange
+        const string seriesName = "Test Series";
+        var dataFrame = ReadOnlyDataFrame.Create([ReadOnlySeries.Create([1, 2, 3], seriesName)]);
+
+        // Act
+        void Act() => dataFrame.Expect<string>(seriesName);
+
+        // Assert
+        _ = Assert.Throws<InvalidDataException>(Act);
+    }
+}

--- a/test/DSE.Open.Numerics.Tests/ReadOnlySeriesExtensionsTests.cs
+++ b/test/DSE.Open.Numerics.Tests/ReadOnlySeriesExtensionsTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+namespace DSE.Open.Numerics;
+
+public sealed class ReadOnlySeriesExtensionsTests
+{
+    [Fact]
+    public void Copied_ShouldReturnEquivalentMutableCopy()
+    {
+        // Arrange
+        const string seriesName = "Test Series";
+
+        var original = ReadOnlySeries.Create([1, 2, 3], seriesName,
+            new ReadOnlyCategorySet<int>([1, 2, 3]),
+            new ReadOnlyValueLabelCollection<int>([
+                new ValueLabel<int>(1, "One"),
+                new ValueLabel<int>(2, "Two"),
+                new ValueLabel<int>(3, "Three")
+            ]));
+
+        // Act
+        var copied = original.Copied();
+
+        // Assert
+        Assert.NotSame(original, copied);
+        Assert.Equal(original.Name, copied.Name);
+        Assert.Equal(original.Length, copied.Length);
+        Assert.Equal(original.Vector, copied.Vector);
+        Assert.Equal(original.Categories, copied.Categories);
+        Assert.Equal(original.ValueLabels, copied.ValueLabels);
+    }
+
+    [Fact]
+    public void Expect_WithMismatchedType_ShouldThrowInvalidDataException()
+    {
+        // Arrange
+        var series = ReadOnlySeries.Create([1, 2, 3], "Test Series");
+
+        // Act
+        void Act() => series.Expect<string>();
+
+        // Assert
+        _ = Assert.Throws<InvalidDataException>(Act);
+    }
+}


### PR DESCRIPTION
This pull request introduces a set of extension methods for read-only collections in the `DSE.Open.Numerics` namespace, enabling operations such as creating mutable copies and type validation. Additionally, unit tests have been added to ensure the correctness of these new methods.

### Unit Tests for New Methods:
* [`test/DSE.Open.Numerics.Tests/ReadOnlyDataFrameExtensionsTests.cs`](diffhunk://#diff-a8672524351574d5128c2d3605467e3fa0015a8b08db1b94478955a9a28037a4R1-R49): Added tests for the `Expect` method in `ReadOnlyDataFrameExtensions`, covering valid retrieval, missing series, and type mismatch scenarios.
* [`test/DSE.Open.Numerics.Tests/ReadOnlySeriesExtensionsTests.cs`](diffhunk://#diff-f8426bf5013ede9f238b95da9b430f7004644971daa9e1306373089747fd3781R1-R46): Added tests for the `Copied` and `Expect` methods in `ReadOnlySeriesExtensions`, ensuring correct behavior for mutable copies and type validation.