### PR TITLE
Get Restext file based off ResourceProvider name

### DIFF
--- a/gen/DSE.Open.Localization.Generators/Resources/ResourceProviderEmitter.cs
+++ b/gen/DSE.Open.Localization.Generators/Resources/ResourceProviderEmitter.cs
@@ -13,7 +13,7 @@ internal static class ResourceProviderEmitter
         IEnumerable<ResourceItem> resourceItems)
     {
         var providerName = model.ProviderName;
-        var resourcesName = model.ResourcesName;
+        var resourcesName = model.ResourcesFullyQualifiedName;
 
         var providerNamespace = model.ProviderNamespace;
         var providerAccessibility = model.ProviderAccessibility;

--- a/gen/DSE.Open.Localization.Generators/Resources/ResourceProviderInformation.cs
+++ b/gen/DSE.Open.Localization.Generators/Resources/ResourceProviderInformation.cs
@@ -13,5 +13,7 @@ internal sealed record ResourceProviderInformation
 
     public string ResourcesName { get; set; } = null!;
 
+    public string ResourcesFullyQualifiedName { get; set; } = null!;
+
     public string ResourcesPath { get; set; } = null!;
 }

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/DSE.Open.Localization.Generators.Tests.Functional.csproj
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/DSE.Open.Localization.Generators.Tests.Functional.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\*.restext" />
     <AdditionalFiles Include="Resources\Strings.restext" />
+    <AdditionalFiles Include="Resources\Strings2.restext" />
   </ItemGroup>
 
 </Project>

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/ResourceProvider2.cs
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/ResourceProvider2.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using DSE.Open.Localization.Generators.Tests.Functional.Resources;
+using DSE.Open.Localization.Resources;
+
+namespace DSE.Open.Localization.Generators.Tests.Functional;
+
+[ResourceProvider(typeof(Strings2))]
+public partial class ResourceProvider2;

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/ResourceProviderGeneratorTests.cs
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/ResourceProviderGeneratorTests.cs
@@ -75,4 +75,25 @@ public sealed class ResourceProviderGeneratorTests
         Assert.Equal(expected, str);
         Assert.Equal(expected, strUs);
     }
+
+    [Fact]
+    public void MultipleResourceProviders_RefrencingDifferentResourceProvider_ShouldGenerateClassForEachResourceProvider()
+    {
+        // Arrange
+        var provider = ResourceProvider.Default;
+        var provider2 = ResourceProvider2.Default;
+        var culture = new CultureInfo("en-US");
+
+        // Act
+        var str = provider.StringsIsDifferentToStrings2(culture);
+        var str2 = provider2.Strings2IsDifferentToStrings(culture);
+
+        // Assert
+        Assert.Equal("This string is different to the one in Strings2.restext", str);
+        Assert.Equal("This string is different to the one in Strings.restext", str2);
+
+        // Verify they are different instances
+        Assert.NotSame(provider, provider2);
+        Assert.NotEqual(provider.GetType(), provider2.GetType());
+    }
 }

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings.restext
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings.restext
@@ -3,3 +3,4 @@ TestTwo = Test two string
 FormattedStringWithTwoHoles = A test string for {Joe} and {Jill}
 FormattedStringWithTwoHolesAndTrailingText = A test string for {Joe} and {Jill} with trailing text
 FormattedStringWithObjectHole = A test string with an object {object:object} hole
+StringsIsDifferentToStrings2 = This string is different to the one in Strings2.restext

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings2.cs
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings2.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Down Syndrome Education International and Contributors licence this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace DSE.Open.Localization.Generators.Tests.Functional.Resources;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed class Strings2;

--- a/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings2.restext
+++ b/test/DSE.Open.Localization.Generators.Tests.Functional/Resources/Strings2.restext
@@ -1,0 +1,2 @@
+
+Strings2IsDifferentToStrings = This string is different to the one in Strings.restext

--- a/test/DSE.Open.Localization.Generators.Tests/Resources/ResourceProviderEmitterTests.cs
+++ b/test/DSE.Open.Localization.Generators.Tests/Resources/ResourceProviderEmitterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
+// Copyright (c) Down Syndrome Education International and Contributors. All Rights Reserved.
 // Down Syndrome Education International and Contributors licence this file to you under the MIT license.
 
 using DSE.Open.Localization.Generators.Resources;
@@ -30,7 +30,7 @@ public sealed class ResourceProviderEmitterTests
         var model = new ResourceProviderInformation
         {
             ProviderName = "ResourceProvider",
-            ResourcesName = "Strings",
+            ResourcesFullyQualifiedName = "Strings",
             ProviderNamespace = "DSE.Open.Localization.Generators.Tests.Functional",
             ProviderAccessibility = "public"
         };
@@ -57,7 +57,7 @@ public sealed class ResourceProviderEmitterTests
         var model = new ResourceProviderInformation
         {
             ProviderName = "ResourceProvider",
-            ResourcesName = "Strings",
+            ResourcesFullyQualifiedName = "Strings",
             ProviderNamespace = "DSE.Open.Localization.Generators.Tests.Functional",
             ProviderAccessibility = "public"
         };
@@ -82,7 +82,7 @@ public sealed class ResourceProviderEmitterTests
         var model = new ResourceProviderInformation
         {
             ProviderName = "ResourceProvider",
-            ResourcesName = "Strings",
+            ResourcesFullyQualifiedName = "Strings",
             ProviderNamespace = "DSE.Open.Localization.Generators.Tests.Functional",
             ProviderAccessibility = "public"
         };


### PR DESCRIPTION
Switches ResourceProviderSourceGenerator to select correct .restext file for each ResourceProvider based off provider name. TryGetFileForResource method now matches the resource file by both directory and file name (without extension), so multiple resource providers referencing different .restext files in the same folder are handled correctly. `

Resolves issues where the wrong resource file could be associated with a provider. Adds support for multiple providers and resource files in the same directory. 